### PR TITLE
Add light version of the 'vsix' icon.

### DIFF
--- a/icons/file_type_light_vsix.svg
+++ b/icons/file_type_light_vsix.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32"><title>file_type_light_vsix</title><path d="M2,16V30H15V24H8V8h7V2H2Z" style="fill:#424242"/><path d="M17,5V8h4V6h5v5H24v4h6V2H17Z" style="fill:#424242"/><path d="M10,16v6H22V10H10Z" style="fill:#424242"/><path d="M24,20.5V24H17v6H30V17H24Z" style="fill:#424242"/></svg>

--- a/src/icon-manifest/supportedExtensions.ts
+++ b/src/icon-manifest/supportedExtensions.ts
@@ -302,7 +302,7 @@ export const extensions: IFileCollection = {
       filename: true,
       format: FileFormat.svg,
     },
-    { icon: 'vsix', extensions: ['vsix'], format: FileFormat.svg },
+    { icon: 'vsix', extensions: ['vsix'], light: true, format: FileFormat.svg },
     { icon: 'vue', extensions: ['vue'], format: FileFormat.svg },
     {
       icon: 'webpack',


### PR DESCRIPTION
Added light version because the icon doesn't look good in a light theme.