### PR TITLE
Associate more names to locale folder icon.

### DIFF
--- a/src/icon-manifest/supportedFolders.ts
+++ b/src/icon-manifest/supportedFolders.ts
@@ -22,7 +22,7 @@ export const extensions: IFolderCollection = {
     { icon: 'js', extensions: ['js'], format: FileFormat.svg },
     { icon: 'images', extensions: ['images', 'image', 'img', 'icons', 'icon', 'ico'], format: FileFormat.svg },
     { icon: 'less', extensions: ['less'], format: FileFormat.svg },
-    { icon: 'locale', extensions: ['locale', 'locales'], format: FileFormat.svg },
+    { icon: 'locale', extensions: ['locale', 'locales', 'i18n', 'g11n'], format: FileFormat.svg },
     { icon: 'node', extensions: ['node_modules'], light: true, format: FileFormat.svg },
     { icon: 'nuget', extensions: ['.nuget'], format: FileFormat.svg },
     { icon: 'paket', extensions: ['.paket'], format: FileFormat.svg },


### PR DESCRIPTION
`i18n` = internationalization
`g11n` = globalization

As seen at https://en.wikipedia.org/wiki/Internationalization_and_localization