### PR TITLE
7.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## 7.1.1 (January 23, 2017)
+  - Fix: Our usual release patch. Fixing angular icons version. ([@robertohuertasm](https://github.com/robertohuertasm) in [#662](https://github.com/vscode-icons/vscode-icons/pull/662))
+
 ## 7.1.0 (January 23, 2017)
   - Fix: Light version icons now work as expected. ([@JimiC](https://github.com/JimiC) in [#660](https://github.com/vscode-icons/vscode-icons/pull/660))
   - Feature: Angular smart components support (`*.page.ts|js` & `*.container.ts|js`). ([@robertohuertasm](https://github.com/robertohuertasm) in [#657](https://github.com/vscode-icons/vscode-icons/pull/657))

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "vscode-icons",
     "displayName": "vscode-icons",
     "description": "Icons for Visual Studio Code",
-    "version": "7.1.0",
+    "version": "7.1.1",
     "publisher": "robertohuertasm",
     "license": "MIT",
     "author": {

--- a/src/settings/extensionSettings.ts
+++ b/src/settings/extensionSettings.ts
@@ -1,7 +1,7 @@
 import { IExtensionSettings } from '../models';
 
 export const extensionSettings: IExtensionSettings = {
-  version: '7.1.0',
+  version: '7.1.1',
   iconJsonFileName: 'icons.json',
   iconSuffix: '',
   filePrefix: 'file_type_',


### PR DESCRIPTION
Somehow the v2 of Angular icons got again as principal. It's strange because I generated the .vsix and check it out but clearly I did something wrong.

Anyway, it's just the usual double release our users are used to and that seems it's not going to abandon us.