### PR TITLE
[Proposal] Disable project auto-detection on this workspace.

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,5 +10,6 @@
         "icons": true,
         "examples": true
     },
-    "typescript.tsdk": "./node_modules/typescript/lib"
-}
+    "typescript.tsdk": "./node_modules/typescript/lib",
+    "vsicons.projectDetection.disableDetect": true
+  }


### PR DESCRIPTION
While developing we want the Angular icons or any other project specific icons to always be shown by default, thus disabling the auto detection on the workspace level is justified.
