### PR TITLE
Update package.json to use as minimum vscode engine version 1.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
         "email": "roberto.huertas@outlook.com"
     },
     "engines": {
-        "vscode": "^1.0.0"
+        "vscode": "^1.5.0"
     },
     "categories": [
         "Other",

--- a/src/models/vscode/vscodeUri.ts
+++ b/src/models/vscode/vscodeUri.ts
@@ -5,6 +5,7 @@ export interface IVSCodeUri {
   query: string;
   fragment: string;
   fsPath: string;
-  toString(): string;
+  with(change: { scheme?: string; authority?: string; path?: string; query?: string; fragment?: string }): IVSCodeUri;
+  toString(skipEncoding?: boolean): string;
   toJSON(): any;
 }


### PR DESCRIPTION
Reasons: 
1. This extension supports `vscode` version `1.5.0` and above.
2. Setting the `vscode engine` version to `1.5.0` fetches more updated type definintions for `vscode` (`vscode.d.ts`).

After merging execute: `npm install` or `yarn install`.