### PR TITLE
Disabled folders were being shown when applying customizations

### DIFF
--- a/src/icon-manifest/manifestMerger.ts
+++ b/src/icon-manifest/manifestMerger.ts
@@ -117,7 +117,7 @@ export function toggleOfficialIconsPreset(
 export function toggleHideFoldersPreset(
   disable: boolean,
   folders: IFolderCollection): IFolderCollection {
-  const folderIcons = folders.supported.map(x => x.icon);
+  const folderIcons = folders.supported.filter(x => !x.disabled).map(x => x.icon);
   const collection = togglePreset<IFolderCollection>(disable, folderIcons, folders);
   if (folders.default.folder) {
    collection.default.folder.disabled = disable;


### PR DESCRIPTION
Typings2 folder was shown whenever I toggled some preset. This PR fixes the issue.
