### PR TITLE
support angular 1.x detection

### DIFF
--- a/src/init/autoDetectProject.ts
+++ b/src/init/autoDetectProject.ts
@@ -60,7 +60,7 @@ export function iconsDisabled(name: string): boolean {
 export function isProject(projectJson: any, name: string): boolean {
   switch (name) {
     case 'ng':
-      return (projectJson.dependencies && (projectJson.dependencies['@angular/core'] != null)) || false;
+      return (projectJson.dependencies && (projectJson.dependencies['@angular/core'] != null || projectJson.dependencies['angular'] != null)) || false;
     default:
       return false;
   }


### PR DESCRIPTION


**Changes proposed:**
* [X ] Add

**Things I've done:**
The current angular detection only works with angular 2.x projects, detecting the presence of the angular/core package. When using angular 1, the icons will not load correctly.
This checks for 'angular' package, which is expected to be present when using angular 1.x

[short comment]
I very much liked the typescript & angular icons support, would be great to have it back again.