### PR TITLE
Change display name of extension.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "vscode-icons",
-    "displayName": "vscode-icons",
+    "displayName": "VSCode Icons",
     "description": "Icons for Visual Studio Code",
     "version": "7.1.2",
     "publisher": "robertohuertasm",


### PR DESCRIPTION
This is a proposal PR.

Currently, the extension's name is displayed as `vscode-icons` in the marketplace. I'm proposing to change it to `VSCode Icons` to get in line with the naming convention the majority of the extensions are using.