### PR TITLE
Add TypeScript extension to Rollup icon

### DIFF
--- a/src/icon-manifest/supportedExtensions.ts
+++ b/src/icon-manifest/supportedExtensions.ts
@@ -252,7 +252,7 @@ export const extensions: IFileCollection = {
     { icon: 'registry', extensions: ['reg'], format: FileFormat.svg },
     { icon: 'riot', extensions: [], languages: [languages.riot], format: FileFormat.svg },
     { icon: 'robotframework', extensions: [], languages: [languages.robot], format: FileFormat.svg },
-    { icon: 'rollup', extensions: ['rollup.config.js'], filename: true, format: FileFormat.svg },
+    { icon: 'rollup', extensions: ['rollup.config.js', 'rollup.config.ts'], filename: true, format: FileFormat.svg },
     { icon: 'rspec', extensions: ['.rspec'], filename: true, format: FileFormat.svg },
     { icon: 'ruby', extensions: [], languages: [languages.ruby], format: FileFormat.svg },
     { icon: 'rust', extensions: [], languages: [languages.rust], format: FileFormat.svg },


### PR DESCRIPTION
**Changes proposed:**
* [x] Add
* [ ] Prepare
* [ ] Delete
* [ ] Fix

**Things I've done:**
* [ ] My pull request fixes an issue, I referenced the issue.

With [@alexlur/rollup-plugin-typescript](https://github.com/alexlur/rollup-plugin-typescript) (and possibly the "official" plugin) you can configure Rollup from a TS file. This PR enables the Rollup icon for that usecase.
