### PR TITLE
Add settings.json and extensions.json to vscode extensions

### DIFF
--- a/src/icon-manifest/supportedExtensions.ts
+++ b/src/icon-manifest/supportedExtensions.ts
@@ -308,8 +308,10 @@ export const extensions: IFileCollection = {
       icon: 'vscode',
       extensions: [
         'vscodeignore.json',
+        'settings.json',
         'launch.json',
         'tasks.json',
+        'extensions.json',
         'jsconfig.json',
         'tsconfig.json',
         '.vscodeignore',


### PR DESCRIPTION
`extensions.json` can be used for "workspace recommendations": https://code.visualstudio.com/Docs/editor/extension-gallery#_workspace-recommended-extensions
