### PR TITLE
Use the regular json icon for launch.json and tasks.json

### DIFF
--- a/src/icon-manifest/supportedExtensions.ts
+++ b/src/icon-manifest/supportedExtensions.ts
@@ -308,8 +308,6 @@ export const extensions: IFileCollection = {
       icon: 'vscode',
       extensions: [
         'vscodeignore.json',
-        'launch.json',
-        'tasks.json',
         'jsconfig.json',
         'tsconfig.json',
         '.vscodeignore',


### PR DESCRIPTION
As discussed in #746
