### PR TITLE
Add _test and _tests mapping for test folder.

### DIFF
--- a/src/icon-manifest/supportedFolders.ts
+++ b/src/icon-manifest/supportedFolders.ts
@@ -33,7 +33,7 @@ export const extensions: IFolderCollection = {
     { icon: 'script', extensions: ['script', 'scripts'], format: FileFormat.svg },
     { icon: 'src', extensions: ['src', 'source', 'sources'], format: FileFormat.svg },
     { icon: 'style', extensions: ['style', 'styles'], format: FileFormat.svg },
-    { icon: 'test', extensions: ['tests', 'test', '__tests__', '__test__', 'spec', 'specs'], format: FileFormat.svg },
+    { icon: 'test', extensions: ['tests', 'test', "_test", "_tests", '__tests__', '__test__', 'spec', 'specs'], format: FileFormat.svg },
     { icon: 'typings', extensions: ['typings'], format: FileFormat.svg },
     { icon: 'typings2', extensions: ['typings'], format: FileFormat.svg, disabled: true },
     { icon: 'view', extensions: ['view', 'views'], format: FileFormat.svg },


### PR DESCRIPTION
We use to name our tests folder "_test" or "_tests". I customized my own personal VSCode but I'm making this PR to make this folder name available for everyone.

**Changes proposed:**
* [x] Add
* [ ] Prepare
* [ ] Delete
* [ ] Fix

Just adding yet another way to name the tests folders. Proposing to add _test and _tests.