### PR TITLE
Remove annoying "is active" output

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -71,8 +71,6 @@ function initialize(context: vscode.ExtensionContext) {
 
 export function activate(context: vscode.ExtensionContext) {
   initialize(context);
-  // tslint:disable-next-line no-console
-  console.log('vscode-icons is active!');
 }
 
 // this method is called when your vscode is closed


### PR DESCRIPTION
I think this is bad practice - it quickly becomes annoying when you're looking for meaningful output in the dev console while developing extensions.