### PR TITLE
Improve detection flow and add a vscode directory handler on cancel.

### DIFF
--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -44,7 +44,8 @@ function registerCommand(
 export function applyCustomizationCommand(): void {
   const message = i18nManager.getMessage(LangResourceKeys.iconCustomizationMessage, LangResourceKeys.restart);
   showCustomizationMessage(message,
-    [{ title: i18nManager.getMessage(LangResourceKeys.reload) }], applyCustomization);
+    [{ title: i18nManager.getMessage(LangResourceKeys.reload) }],
+    applyCustomization);
 }
 
 function restoreDefaultManifestCommand(): void {
@@ -118,11 +119,11 @@ function getToggleValue(preset: string): boolean {
 
 export function updatePreset(
   preset: string,
-  newvalue: boolean,
+  newValue: boolean,
   initValue: boolean,
   global: boolean = true): Thenable<void> {
 
-  return getConfig().update(`vsicons.presets.${preset}`, initValue === undefined ? initValue : newvalue, global);
+  return getConfig().update(`vsicons.presets.${preset}`, initValue === undefined ? initValue : newValue, global);
 }
 
 export function showCustomizationMessage(
@@ -148,7 +149,7 @@ export function showCustomizationMessage(
         getConfig().update('vsicons.projectDetection.autoReload', true, true);
       }
 
-      if (callback) { callback(...args); }
+      if (callback) { callback(); }
 
       reload();
     }, (reason) => {
@@ -162,8 +163,20 @@ export function reload(): void {
   vscode.commands.executeCommand('workbench.action.reloadWindow');
 }
 
-export function cancel(preset: string, value: boolean, initValue: boolean, global: boolean = true): void {
-  updatePreset(preset, value, initValue, global);
+export function cancel(
+  preset: string,
+  value: boolean,
+  initValue: boolean,
+  global: boolean = true,
+  callback?: Function): void {
+  updatePreset(preset, value, initValue, global)
+    .then(() => {
+      setTimeout(() => {
+        if (callback) {
+          callback();
+        }
+      }, 1000);
+    });
 }
 
 export function applyCustomization(): void {

--- a/src/icon-manifest/manifestMerger.ts
+++ b/src/icon-manifest/manifestMerger.ts
@@ -103,8 +103,7 @@ export function toggleOfficialIconsPreset(
   disable: boolean,
   customFiles: IFileCollection,
   officialIcons: string[],
-  defaultIcons: string[],
-  ): IFileCollection {
+  defaultIcons: string[]): IFileCollection {
   const temp = togglePreset(disable, officialIcons, customFiles);
   return togglePreset(!disable, defaultIcons, temp);
 }

--- a/src/init/autoApplyCustomizations.ts
+++ b/src/init/autoApplyCustomizations.ts
@@ -4,11 +4,11 @@ import * as packageJson from '../../../package.json';
 export function manageAutoApplyCustomizations(
   isNewVersion: boolean,
   userConfig: IVSIcons,
-  applyCustomizationCommand: () => void): void {
+  applyCustomizationCommand: Function): void {
   if (!isNewVersion) { return; }
   const propObj = (packageJson as any).contributes.configuration.properties as Object;
   for (const key in propObj) {
-    if (propObj.hasOwnProperty(key) && key !== 'dontShowNewVersionMessage') {
+    if (Reflect.has(propObj, key) && key !== 'vsicons.dontShowNewVersionMessage') {
       const defaultValue = propObj[key].default;
       const parts = key.split('.').filter(x => x !== 'vsicons');
       const userValue = parts.reduce((prev, current) => prev[current], userConfig);

--- a/src/init/autoDetectProject.ts
+++ b/src/init/autoDetectProject.ts
@@ -41,7 +41,6 @@ export function checkForAngularProject(
 
   return { apply: false };
 }
-
 export function iconsDisabled(name: string): boolean {
   const manifestFilePath = path.join(__dirname, '..', extensionSettings.iconJsonFileName);
   const iconManifest = fs.readFileSync(manifestFilePath, 'utf8');
@@ -59,7 +58,6 @@ export function iconsDisabled(name: string): boolean {
 
   return true;
 }
-
 export function isProject(projectJson: any, name: string): boolean {
   switch (name) {
     case 'ng':
@@ -70,6 +68,7 @@ export function isProject(projectJson: any, name: string): boolean {
 }
 
 export function applyDetection(
+  i18nManager: LanguageResourceManager,
   message: string,
   presetText: string,
   value: boolean,
@@ -78,10 +77,10 @@ export function applyDetection(
   autoReload: boolean,
   updatePreset: Function,
   applyCustomization: Function,
+  showCustomizationMessage: Function,
   reload: Function,
   cancel: Function,
-  showCustomizationMessage: Function,
-  i18nManager: LanguageResourceManager): Thenable<void> {
+  handleVSCodeDir: Function): Thenable<void> {
   return updatePreset(presetText, value, defaultValue, false)
     .then(() => {
       // Add a delay in order for vscode to persist the toggle of the preset
@@ -98,6 +97,6 @@ export function applyDetection(
         [{ title: i18nManager.getMessage(LangResourceKeys.reload) },
         { title: i18nManager.getMessage(LangResourceKeys.autoReload) },
         { title: i18nManager.getMessage(LangResourceKeys.disableDetect) }],
-        applyCustomization, cancel, presetText, !value, initValue, false);
+        applyCustomization, cancel, presetText, !value, initValue, false, handleVSCodeDir);
     });
 }

--- a/test/autoDetectProject.test.ts
+++ b/test/autoDetectProject.test.ts
@@ -189,10 +189,11 @@ describe('AutoDetectProject: tests', function () {
           const applyCustomization = sinon.spy();
           const reload = sinon.spy();
           const cancel = sinon.stub();
+          const handleVSCodeDir = sinon.stub();
           const showCustomizationMessage = sinon.spy();
 
-          return applyDetection(undefined, undefined, undefined, undefined, undefined, autoReload,
-            updatePreset, applyCustomization, reload, cancel, showCustomizationMessage, undefined)
+          return applyDetection(undefined, undefined, undefined, undefined, undefined, undefined, autoReload,
+            updatePreset, applyCustomization, showCustomizationMessage, reload, cancel, handleVSCodeDir)
             .then(() => {
               // No functions should have been called before 1s
               clock.tick(999);
@@ -217,11 +218,12 @@ describe('AutoDetectProject: tests', function () {
           const applyCustomization = sinon.spy();
           const reload = sinon.spy();
           const cancel = sinon.spy();
+          const handleVSCodeDir = sinon.stub();
           const showCustomizationMessage = sinon.spy();
           const i18nManager = sinon.createStubInstance(LanguageResourceManager);
 
-          return applyDetection(undefined, undefined, undefined, undefined, undefined, autoReload,
-            updatePreset, applyCustomization, reload, cancel, showCustomizationMessage, i18nManager)
+          return applyDetection(i18nManager, undefined, undefined, undefined, undefined, undefined, autoReload,
+            updatePreset, applyCustomization, showCustomizationMessage, reload, cancel, handleVSCodeDir)
             .then(() => {
               expect(showCustomizationMessage.called).to.be.true;
             });


### PR DESCRIPTION
I have noticed that when a project doesn't have a user level `settings.json` file or a `.vscode` directory in general, the way we handle the project detection leaves some `garbage` behind when the user cancels the action on the prompt message.

This PR improves the detection flow and handles canceling cases by removing its `echo`.
