### PR TITLE
Exclude '.bithoundrc' from distribution.

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -10,6 +10,7 @@ typings/**
 examples/**
 images/screenshot.gif
 Dockerfile
+.bithoundrc
 .editorconfig
 .gitignore
 .gitattributes
@@ -18,4 +19,3 @@ tsconfig.json
 tslint.json
 npm-debug.*
 yarn.lock
-


### PR DESCRIPTION
Sorry guys, my bad. Forgot to add it in `.vscodeignore`.
