### PR TITLE
Add the vscode directory handling on presets toggle.

### DIFF
--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -17,6 +17,7 @@ import {
   LangResourceKeys,
 } from '../models';
 import { extensionSettings } from '../settings';
+import { handleVSCodeDir } from '../';
 
 const i18nManager = new LanguageResourceManager(vscode.env.language);
 
@@ -90,7 +91,7 @@ function togglePreset(
   updatePreset(preset, value, defaultValue as boolean, global);
   showCustomizationMessage(message,
     [{ title: i18nManager.getMessage(LangResourceKeys.reload) }],
-    applyCustomization, cancel, preset, !value, initValue, global);
+    applyCustomization, cancel, preset, !value, initValue, global, handleVSCodeDir);
 }
 
 function toggleAngularPresetCommand(): void {

--- a/src/index.ts
+++ b/src/index.ts
@@ -79,7 +79,7 @@ function detectAngular(config: IVSIcons, results: IVSCodeUri[]): void {
     reload, cancel, handleVSCodeDir);
 }
 
-function handleVSCodeDir(): void {
+export function handleVSCodeDir(): void {
   const vscodeDirPath = `${vscode.workspace.rootPath}/.vscode`;
   const userSettingsPath = `${vscodeDirPath}/settings.json`;
 


### PR DESCRIPTION
Now that we have inverted the preset for Angular icons the `.vscode` directory handling has to be added to the toggle function as well.
