### PR TITLE
Expand extensions list for `dist` folder icon

### DIFF
--- a/src/icon-manifest/supportedFolders.ts
+++ b/src/icon-manifest/supportedFolders.ts
@@ -13,7 +13,7 @@ export const extensions: IFolderCollection = {
     { icon: 'aws', extensions: ['aws', '.aws'], format: FileFormat.svg },
     { icon: 'bower', extensions: ['bower_components'], format: FileFormat.svg },
     { icon: 'css', extensions: ['css'], format: FileFormat.svg },
-    { icon: 'dist', extensions: ['dist', 'out', 'export', 'build'], format: FileFormat.svg },
+    { icon: 'dist', extensions: ['dist', 'out', 'export', 'build', 'release'], format: FileFormat.svg },
     { icon: 'docs', extensions: ['docs'], format: FileFormat.svg },
     { icon: 'elasticbeanstalk', extensions: ['.elasticbeanstalk', '.ebextensions'], format: FileFormat.svg },
     { icon: 'flow', extensions: ['flow'], format: FileFormat.svg },


### PR DESCRIPTION
**Changes proposed:**
* [x] Add
* [ ] Prepare
* [ ] Delete
* [ ] Fix

**Things I've done:**
* [x] My pull request fixes an issue, I referenced the issue.

_This PR partially addresses one of the goals in #650 by adding an icon for `lib` folders. If this isn't acceptable it can be dropped._

Reason: `lib` and `release` are common patterns for distribution folders; as an example, Angular UI Router has used both: [release](https://github.com/angular-ui/ui-router/blob/624d94ea924b4d0c113e3bf7ee8c0439e73e8247/package.json#L92), [lib](https://github.com/angular-ui/ui-router/blob/master/package.json#L62)

Ambiguities: Some libraries use `lib` in different ways; for instance, as a source folder or a side-by-side resource with `dist` in the published library. However, the common case (as I understand it) is for `lib` to be some kind of resource meant to be consumed by an end user, mildly analogous to `node_modules`.