### PR TITLE
Change the order the folder icons presets are applied.

### DIFF
--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -206,14 +206,14 @@ function generateManifest(
       ['json_official'], ['json']);
   }
   if (customFolders) {
-    workingCustomFolders = iconManifest.toggleHideFoldersPreset(presets.hideFolders, workingCustomFolders);
     workingCustomFolders = iconManifest.toggleFoldersAllDefaultIconPreset(
       presets.foldersAllDefaultIcon, workingCustomFolders);
+    workingCustomFolders = iconManifest.toggleHideFoldersPreset(presets.hideFolders, workingCustomFolders);
   }
   // presets affecting default icons
   const workingFiles = iconManifest.toggleAngularPreset(!presets.angular, files);
-  let workingFolders = iconManifest.toggleHideFoldersPreset(presets.hideFolders, folders);
-  workingFolders = iconManifest.toggleFoldersAllDefaultIconPreset(presets.foldersAllDefaultIcon, workingFolders);
+  let workingFolders = iconManifest.toggleFoldersAllDefaultIconPreset(presets.foldersAllDefaultIcon, folders);
+  workingFolders = iconManifest.toggleHideFoldersPreset(presets.hideFolders, workingFolders);
 
   const json = iconManifest.mergeConfig(
     workingCustomFiles,


### PR DESCRIPTION
I noticed a bug with the new feature of using the default icon for all folders.
That preset was overriding the `hide all folders` preset, so I change the order that the presets are applied.
It makes sense that even if the user has set all folder to have the default icon when setting to hide the folder icons it has to be the last applied preset.
