### PR TITLE
add styl extension to stylus entry of supportedExtensions

### DIFF
--- a/src/icon-manifest/supportedExtensions.ts
+++ b/src/icon-manifest/supportedExtensions.ts
@@ -290,7 +290,7 @@ export const extensions: IFileCollection = {
     { icon: 'sss', extensions: ['sss'], format: FileFormat.svg },
     { icon: 'style', extensions: [], format: FileFormat.svg },
     { icon: 'stylelint', extensions: ['.stylelintrc', 'stylelint.config.js', '.stylelintignore'], light: true, filename: true, format: FileFormat.svg },
-    { icon: 'stylus', extensions: [], languages: [languages.stylus], format: FileFormat.svg },
+    { icon: 'stylus', extensions: ['styl'], languages: [languages.stylus], format: FileFormat.svg },
     { icon: 'storyboard', extensions: ['storyboard'], format: FileFormat.svg },
     { icon: 'svg', extensions: ['svg'], format: FileFormat.svg },
     { icon: 'swagger', extensions: [], languages: [languages.swagger], format: FileFormat.svg },


### PR DESCRIPTION
***Fixes #650 ***

[Add styl extension for stylus support](https://github.com/vscode-icons/vscode-icons/issues/650#issuecomment-287698758)

**Changes proposed:**
* [ x ] Add
* [ ] Prepare
* [ ] Delete
* [ ] Fix

**Things I've done:**
* [ x] My pull request fixes an issue, I referenced the issue.

Not sure what else to do in order to (properly) add `styl` extension.
Thanks
