### PR TITLE
Add support for graphql icon (#845)

### DIFF
--- a/src/icon-manifest/supportedExtensions.ts
+++ b/src/icon-manifest/supportedExtensions.ts
@@ -152,7 +152,7 @@ export const extensions: IFileCollection = {
     { icon: 'go', extensions: [], languages: [languages.go], format: FileFormat.svg },
     { icon: 'godot', extensions: [], languages: [languages.godot], format: FileFormat.svg },
     { icon: 'gradle', extensions: ['gradle'], format: FileFormat.svg },
-    { icon: 'graphql', extensions: [], languages: [languages.graphql], format: FileFormat.svg },
+    { icon: 'graphql', extensions: ['graphql', 'gql'], languages: [languages.graphql], format: FileFormat.svg },
     { icon: 'graphviz', extensions: [], languages: [languages.graphviz], format: FileFormat.svg },
     { icon: 'groovy', extensions: [], languages: [languages.groovy], format: FileFormat.svg },
     { icon: 'groovy2', extensions: [], languages: [languages.groovy], format: FileFormat.svg, disabled: true },


### PR DESCRIPTION
***Fixes #845***

**Changes proposed:**
* [x] Add
* [ ] Prepare
* [ ] Delete
* [ ] Fix

**Things I've done:**
* [x] My pull request fixes an issue, I referenced the issue.

Add missed ".graphql" and ".gql" extensions for files to support graphql icon.
