### PR TITLE
Add default config filename for jest

### DIFF
--- a/src/icon-manifest/supportedExtensions.ts
+++ b/src/icon-manifest/supportedExtensions.ts
@@ -204,7 +204,7 @@ export const extensions: IFileCollection = {
     { icon: 'java', extensions: [], languages: [languages.java], format: FileFormat.svg },
     { icon: 'jbuilder', extensions: ['jbuilder'], format: FileFormat.svg },
     { icon: 'jenkins', extensions: ['jenkinsfile'], filename: true, format: FileFormat.svg },
-    { icon: 'jest', extensions: ['jest.json', 'jest.config.json', '.jestrc'], filename: true, format: FileFormat.svg },
+    { icon: 'jest', extensions: ['jest.config.js', 'jest.json', 'jest.config.json', '.jestrc'], filename: true, format: FileFormat.svg },
     { icon: 'jinja', extensions: [], languages: [languages.jinja], format: FileFormat.svg },
     { icon: 'js', extensions: [], languages: [languages.javascript], format: FileFormat.svg },
     { icon: 'js_official', extensions: [], languages: [languages.javascript], format: FileFormat.svg, disabled: true },


### PR DESCRIPTION
**Changes proposed:**
* [x] Add

**Things I've done:**
* [x] Added `jest.config.js` for the Jest icon

So jest is a bit weird with their configs. They seem to have been half-assing it till now and in the last version they broke `.jestrc` entirely (There has to be a file extention or bust).

[Their docs dictate `jest.config.js`](https://facebook.github.io/jest/docs/en/configuration.html#content) as the only auto-discovered config filename.
