### PR TITLE
Fix missing i18n of configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -154,7 +154,7 @@
                 "vsicons.presets.foldersAllDefaultIcon": {
                     "type": "boolean",
                     "default": false,
-                    "description": "configuration.presets.foldersAllDefaultIcon.description"
+                    "description": "%configuration.presets.foldersAllDefaultIcon.description%"
                 },
                 "vsicons.associations.files": {
                     "type": "array",


### PR DESCRIPTION
**Changes proposed:**
* [ ] Add
* [ ] Prepare
* [ ] Delete
* [x] Fix

Fix missing i18n of configuration item `vsicons.presets.foldersAllDefaultIcon`
