### PR TITLE
Update badges links of README to resolve to HTTPS.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,23 +7,23 @@
 [![Build Status](https://travis-ci.org/vscode-icons/vscode-icons.svg?branch=master)](https://travis-ci.org/vscode-icons/vscode-icons)
 [![Build Status](https://ci.appveyor.com/api/projects/status/github/vscode-icons/vscode-icons?branch=master&svg=true)](https://ci.appveyor.com/project/robertohuertasm/vscode-icons)
 
-[![Dependencies Status](https://david-dm.org/vscode-icons/vscode-icons/status.svg?=1)](https://david-dm.org/vscode-icons/vscode-icons)
-[![DevDependencies Status](https://david-dm.org/vscode-icons/vscode-icons/dev-status.svg?=1)](https://david-dm.org/vscode-icons/vscode-icons?type=dev)
-[![Greenkeeper badge](https://badges.greenkeeper.io/vscode-icons/vscode-icons.svg?=1)](https://greenkeeper.io/)
+[![Dependencies Status](https://david-dm.org/vscode-icons/vscode-icons/status.svg)](https://david-dm.org/vscode-icons/vscode-icons)
+[![DevDependencies Status](https://david-dm.org/vscode-icons/vscode-icons/dev-status.svg)](https://david-dm.org/vscode-icons/vscode-icons?type=dev)
+[![Greenkeeper badge](https://badges.greenkeeper.io/vscode-icons/vscode-icons.svg)](https://greenkeeper.io/)
 
-[![codecov](https://codecov.io/gh/vscode-icons/vscode-icons/branch/master/graph/badge.svg?=1)](https://codecov.io/gh/vscode-icons/vscode-icons)
-[![Known Vulnerabilities](https://snyk.io/test/github/vscode-icons/vscode-icons/badge.svg?=1)](https://snyk.io/test/github/vscode-icons/vscode-icons)
+[![codecov](https://codecov.io/gh/vscode-icons/vscode-icons/branch/master/graph/badge.svg)](https://codecov.io/gh/vscode-icons/vscode-icons)
+[![Known Vulnerabilities](https://snyk.io/test/github/vscode-icons/vscode-icons/badge.svg)](https://snyk.io/test/github/vscode-icons/vscode-icons)
 
-[![bitHound Overall Score](https://www.bithound.io/github/vscode-icons/vscode-icons/badges/score.svg?=1)](https://www.bithound.io/github/vscode-icons/vscode-icons)
-[![bitHound Dependencies](https://www.bithound.io/github/vscode-icons/vscode-icons/badges/dependencies.svg?=1)](https://www.bithound.io/github/vscode-icons/vscode-icons/master/dependencies/npm)
-[![bitHound Dev Dependencies](https://www.bithound.io/github/vscode-icons/vscode-icons/badges/devDependencies.svg?=1)](https://www.bithound.io/github/vscode-icons/vscode-icons/master/dependencies/npm)
-[![bitHound Code](https://www.bithound.io/github/vscode-icons/vscode-icons/badges/code.svg?=1)](https://www.bithound.io/github/vscode-icons/vscode-icons)
+[![bitHound Overall Score](https://www.bithound.io/github/vscode-icons/vscode-icons/badges/score.svg)](https://www.bithound.io/github/vscode-icons/vscode-icons)
+[![bitHound Dependencies](https://www.bithound.io/github/vscode-icons/vscode-icons/badges/dependencies.svg)](https://www.bithound.io/github/vscode-icons/vscode-icons/master/dependencies/npm)
+[![bitHound Dev Dependencies](https://www.bithound.io/github/vscode-icons/vscode-icons/badges/devDependencies.svg)](https://www.bithound.io/github/vscode-icons/vscode-icons/master/dependencies/npm)
+[![bitHound Code](https://www.bithound.io/github/vscode-icons/vscode-icons/badges/code.svg)](https://www.bithound.io/github/vscode-icons/vscode-icons)
 
-[![Average time to resolve an issue](https://isitmaintained.com/badge/resolution/vscode-icons/vscode-icons.svg?=1)](http://isitmaintained.com/project/vscode-icons/vscode-icons "Average time to resolve an issue")
-[![Percentage of issues still open](https://isitmaintained.com/badge/open/vscode-icons/vscode-icons.svg?=1)](http://isitmaintained.com/project/vscode-icons/vscode-icons "Percentage of issues still open")
+[![Average time to resolve an issue](https://isitmaintained.com/badge/resolution/vscode-icons/vscode-icons.svg)](https://isitmaintained.com/project/vscode-icons/vscode-icons "Average time to resolve an issue")
+[![Percentage of issues still open](https://isitmaintained.com/badge/open/vscode-icons/vscode-icons.svg)](https://isitmaintained.com/project/vscode-icons/vscode-icons "Percentage of issues still open")
 
-[![Issue Stats](http://issuestats.com/github/vscode-icons/vscode-icons/badge/issue?style=flat)](http://issuestats.com/github/vscode-icons/vscode-icons)
-[![Issue Stats](http://issuestats.com/github/vscode-icons/vscode-icons/badge/pr?style=flat)](http://issuestats.com/github/vscode-icons/vscode-icons)
+[![Issue Stats](https://issuestats.com/github/vscode-icons/vscode-icons/badge/issue?style=flat)](https://issuestats.com/github/vscode-icons/vscode-icons)
+[![Issue Stats](https://issuestats.com/github/vscode-icons/vscode-icons/badge/pr?style=flat)](https://issuestats.com/github/vscode-icons/vscode-icons)
 
 
 Bring icons to your VS Code.

--- a/README.md
+++ b/README.md
@@ -22,9 +22,6 @@
 [![Average time to resolve an issue](https://isitmaintained.com/badge/resolution/vscode-icons/vscode-icons.svg)](https://isitmaintained.com/project/vscode-icons/vscode-icons "Average time to resolve an issue")
 [![Percentage of issues still open](https://isitmaintained.com/badge/open/vscode-icons/vscode-icons.svg)](https://isitmaintained.com/project/vscode-icons/vscode-icons "Percentage of issues still open")
 
-[![Issue Stats](https://issuestats.com/github/vscode-icons/vscode-icons/badge/issue?style=flat)](https://issuestats.com/github/vscode-icons/vscode-icons)
-[![Issue Stats](https://issuestats.com/github/vscode-icons/vscode-icons/badge/pr?style=flat)](https://issuestats.com/github/vscode-icons/vscode-icons)
-
 
 Bring icons to your VS Code.
 


### PR DESCRIPTION
Updated badge links in README to resolve to `https` according to https://github.com/Microsoft/vscode-docs/blob/vnext/release-notes/v1_14.md#changes-for-extension-authors.

**Note:** I have requested so that the `vscode` team adds also `codecov.io` to trusted badge provider list (https://github.com/Microsoft/vscode-docs/issues/1055).
`issuestats` may not render correctly or link to the site will be presented with warming until the author switches to self-signed SSL cert.
