### PR TITLE
Update dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2,17 +2,18 @@
     "name": "vscode-icons",
     "version": "7.10.1",
     "lockfileVersion": 1,
+    "requires": true,
     "dependencies": {
         "@types/chai": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.0.0.tgz",
-            "integrity": "sha512-B56eI1x+Av9A7XHsgF0+WyLyBytAQqvdBoaULY3c4TGeKwLm43myB78EeBA8/VQn74KblXM4/ecmjTJJXUUF1A==",
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.0.1.tgz",
+            "integrity": "sha512-DWrdkraJO+KvBB7+Jc6AuDd2+fwV6Z9iK8cqEEoYpcurYrH7GiUZmwjFuQIIWj5HhFz6NsSxdN72YMIHT7Fy2Q==",
             "dev": true
         },
         "@types/lodash": {
-            "version": "4.14.66",
-            "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.66.tgz",
-            "integrity": "sha512-LpGSiIy5/utq8AT2bSXGnENnS1kCZJ1m84L1yqKst2UehSZe6VWROmiysYg/lLJR6zu2ooeVoQtkUHToA+mEtQ==",
+            "version": "4.14.68",
+            "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.68.tgz",
+            "integrity": "sha512-tndmbhJc7EeymtvgcZ0oX2H0P95VcT1FlAoeki3bl71DqL9zA/tbJcMZyR1kJkHDvr+57I7+gsn+BVPHIqgcbQ==",
             "dev": true
         },
         "@types/mocha": {
@@ -28,22 +29,26 @@
             "dev": true
         },
         "@types/node": {
-            "version": "7.0.31",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-7.0.31.tgz",
-            "integrity": "sha512-+KrE1LDddn97ip+gXZAnzNQ0pupKH/6tcKwTpo96BDVNpzmhIKGHug0Wd3H0dN4WEqYB1tXYI5m2mZuIZNI8tg==",
+            "version": "7.0.33",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-7.0.33.tgz",
+            "integrity": "sha512-8fVvl6Yyk3jZvSYxRMS9/AmZJ5RXCOP9N4xSlykyBViVESu751pxHYTN14Embn1Fem78YwEHdC7p7KGQQpwunw==",
             "dev": true
         },
         "@types/sinon": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-2.3.1.tgz",
-            "integrity": "sha512-WXpK6gOice0sdhfrAtRaDNtg0E0e04MRuCKYuqtCmc8O1P9P+ia3Z5zuMf4cDVB27s9w4UjjML5/6vjkiI2gNA==",
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-2.3.2.tgz",
+            "integrity": "sha512-92DKsC/9bnsfyBLdY5AP8Zk7LDbwVF0hBHsfQ3IY3kHXEo3NdJA57090wGmzcnITxupyvR3lXk278tPktM6OJw==",
             "dev": true
         },
         "ajv": {
             "version": "4.11.8",
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
             "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "co": "4.6.0",
+                "json-stable-stringify": "1.0.1"
+            }
         },
         "ansi-regex": {
             "version": "2.1.1",
@@ -67,12 +72,15 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
             "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "arr-flatten": "1.1.0"
+            }
         },
         "arr-flatten": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.3.tgz",
-            "integrity": "sha1-onTthawIhJtr14R8RYB0XcUa37E=",
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
+            "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
             "dev": true
         },
         "array-differ": {
@@ -85,7 +93,10 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
             "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "array-uniq": "1.0.3"
+            }
         },
         "array-uniq": {
             "version": "1.0.3",
@@ -124,10 +135,13 @@
             "dev": true
         },
         "async": {
-            "version": "2.4.1",
-            "resolved": "https://registry.npmjs.org/async/-/async-2.4.1.tgz",
-            "integrity": "sha1-YqVrJ5yYoR0JhwlqAcw+6463u9c=",
-            "dev": true
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/async/-/async-2.5.0.tgz",
+            "integrity": "sha512-e+lJAJeNWuPCNyxZKOBdaJGyLGHugXVQtrAwtuAe2vhxTYxFTKE73p8JuTmdH0qdQZtDvI4dhJwjZc5zsfIsYw==",
+            "dev": true,
+            "requires": {
+                "lodash": "4.17.4"
+            }
         },
         "asynckit": {
             "version": "0.4.0",
@@ -151,7 +165,12 @@
             "version": "6.22.0",
             "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
             "integrity": "sha1-AnYgvuVnqIwyVhV05/0IAdMxGOQ=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "chalk": "1.1.3",
+                "esutils": "2.0.2",
+                "js-tokens": "3.0.2"
+            }
         },
         "balanced-match": {
             "version": "1.0.0",
@@ -164,7 +183,10 @@
             "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
             "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
             "dev": true,
-            "optional": true
+            "optional": true,
+            "requires": {
+                "tweetnacl": "0.14.5"
+            }
         },
         "beeper": {
             "version": "1.1.1",
@@ -176,31 +198,54 @@
             "version": "1.7.0",
             "resolved": "https://registry.npmjs.org/bithound/-/bithound-1.7.0.tgz",
             "integrity": "sha1-0xooCM4+ynHoe13vWmWTXEZJidc=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "async": "2.5.0",
+                "commander": "2.11.0",
+                "git-origin-url": "0.3.0",
+                "git-rev-sync": "1.9.1",
+                "open": "0.0.5",
+                "request": "2.81.0"
+            }
         },
         "block-stream": {
             "version": "0.0.9",
             "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
             "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "inherits": "2.0.3"
+            }
         },
         "boom": {
             "version": "2.10.1",
             "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
             "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "hoek": "2.16.3"
+            }
         },
         "brace-expansion": {
             "version": "1.1.8",
             "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
             "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "balanced-match": "1.0.0",
+                "concat-map": "0.0.1"
+            }
         },
         "braces": {
             "version": "1.8.5",
             "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
             "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "expand-range": "1.8.2",
+                "preserve": "0.2.0",
+                "repeat-element": "1.1.2"
+            }
         },
         "browser-stdout": {
             "version": "1.3.0",
@@ -224,13 +269,28 @@
             "version": "4.0.2",
             "resolved": "https://registry.npmjs.org/chai/-/chai-4.0.2.tgz",
             "integrity": "sha1-L3MnxN5vOF3XeHmZ4qsCaXoyuDs=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "assertion-error": "1.0.2",
+                "check-error": "1.0.2",
+                "deep-eql": "2.0.2",
+                "get-func-name": "2.0.0",
+                "pathval": "1.1.0",
+                "type-detect": "4.0.3"
+            }
         },
         "chalk": {
             "version": "1.1.3",
             "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
             "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "ansi-styles": "2.2.1",
+                "escape-string-regexp": "1.0.5",
+                "has-ansi": "2.0.0",
+                "strip-ansi": "3.0.1",
+                "supports-color": "2.0.0"
+            }
         },
         "check-error": {
             "version": "1.0.2",
@@ -260,7 +320,12 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/cloneable-readable/-/cloneable-readable-1.0.0.tgz",
             "integrity": "sha1-pikNQT8hemEjL5XkWP84QYz7ARc=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "inherits": "2.0.3",
+                "process-nextick-args": "1.0.7",
+                "through2": "2.0.3"
+            }
         },
         "co": {
             "version": "4.6.0",
@@ -273,6 +338,11 @@
             "resolved": "https://registry.npmjs.org/codecov/-/codecov-2.2.0.tgz",
             "integrity": "sha1-LQaBfOuIkeymNog21Ptr9swE/9E=",
             "dev": true,
+            "requires": {
+                "argv": "0.0.2",
+                "request": "2.79.0",
+                "urlgrey": "0.4.4"
+            },
             "dependencies": {
                 "caseless": {
                     "version": "0.11.0",
@@ -284,7 +354,13 @@
                     "version": "2.0.6",
                     "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
                     "integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "chalk": "1.1.3",
+                        "commander": "2.11.0",
+                        "is-my-json-valid": "2.16.0",
+                        "pinkie-promise": "2.0.1"
+                    }
                 },
                 "qs": {
                     "version": "6.3.2",
@@ -296,7 +372,29 @@
                     "version": "2.79.0",
                     "resolved": "https://registry.npmjs.org/request/-/request-2.79.0.tgz",
                     "integrity": "sha1-Tf5b9r6LjNw3/Pk+BLZVd3InEN4=",
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "aws-sign2": "0.6.0",
+                        "aws4": "1.6.0",
+                        "caseless": "0.11.0",
+                        "combined-stream": "1.0.5",
+                        "extend": "3.0.1",
+                        "forever-agent": "0.6.1",
+                        "form-data": "2.1.4",
+                        "har-validator": "2.0.6",
+                        "hawk": "3.1.3",
+                        "http-signature": "1.1.1",
+                        "is-typedarray": "1.0.0",
+                        "isstream": "0.1.2",
+                        "json-stringify-safe": "5.0.1",
+                        "mime-types": "2.1.15",
+                        "oauth-sign": "0.8.2",
+                        "qs": "6.3.2",
+                        "stringstream": "0.0.5",
+                        "tough-cookie": "2.3.2",
+                        "tunnel-agent": "0.4.3",
+                        "uuid": "3.1.0"
+                    }
                 },
                 "tunnel-agent": {
                     "version": "0.4.3",
@@ -316,12 +414,15 @@
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
             "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "delayed-stream": "1.0.0"
+            }
         },
         "commander": {
-            "version": "2.9.0",
-            "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
-            "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
+            "version": "2.11.0",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
+            "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
             "dev": true
         },
         "concat-map": {
@@ -346,13 +447,19 @@
             "version": "2.0.5",
             "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
             "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "boom": "2.10.1"
+            }
         },
         "dashdash": {
             "version": "1.14.1",
             "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
             "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
             "dev": true,
+            "requires": {
+                "assert-plus": "1.0.0"
+            },
             "dependencies": {
                 "assert-plus": {
                     "version": "1.0.0",
@@ -372,19 +479,28 @@
             "version": "2.6.0",
             "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.0.tgz",
             "integrity": "sha1-vFlryr52F/Edn6FTYe3tVgi4SZs=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "ms": "0.7.2"
+            }
         },
         "deep-assign": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/deep-assign/-/deep-assign-1.0.0.tgz",
             "integrity": "sha1-sJJ0O+hCfcYh6gBnzex+cN0Z83s=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "is-obj": "1.0.1"
+            }
         },
         "deep-eql": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-2.0.2.tgz",
             "integrity": "sha1-sbrAblbwp2d3aG1Qyf63XC7XZ5o=",
             "dev": true,
+            "requires": {
+                "type-detect": "3.0.0"
+            },
             "dependencies": {
                 "type-detect": {
                     "version": "3.0.0",
@@ -417,12 +533,21 @@
             "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
             "integrity": "sha1-xhTc9n4vsUmVqRcR5aYX6KYKMds=",
             "dev": true,
+            "requires": {
+                "readable-stream": "1.1.14"
+            },
             "dependencies": {
                 "readable-stream": {
                     "version": "1.1.14",
                     "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
                     "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "core-util-is": "1.0.2",
+                        "inherits": "2.0.3",
+                        "isarray": "0.0.1",
+                        "string_decoder": "0.10.31"
+                    }
                 },
                 "string_decoder": {
                     "version": "0.10.31",
@@ -436,26 +561,41 @@
             "version": "3.5.0",
             "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.5.0.tgz",
             "integrity": "sha1-GqdzAC4VeEV+nZ1KULDMquvL1gQ=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "end-of-stream": "1.0.0",
+                "inherits": "2.0.3",
+                "readable-stream": "2.3.3",
+                "stream-shift": "1.0.0"
+            }
         },
         "ecc-jsbn": {
             "version": "0.1.1",
             "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
             "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
             "dev": true,
-            "optional": true
+            "optional": true,
+            "requires": {
+                "jsbn": "0.1.1"
+            }
         },
         "end-of-stream": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.0.0.tgz",
             "integrity": "sha1-1FlucCc0qT5A6a+GQxnqvZn/Lw4=",
             "dev": true,
+            "requires": {
+                "once": "1.3.3"
+            },
             "dependencies": {
                 "once": {
                     "version": "1.3.3",
                     "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
                     "integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA=",
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "wrappy": "1.0.2"
+                    }
                 }
             }
         },
@@ -475,19 +615,34 @@
             "version": "3.3.4",
             "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
             "integrity": "sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "duplexer": "0.1.1",
+                "from": "0.1.7",
+                "map-stream": "0.1.0",
+                "pause-stream": "0.0.11",
+                "split": "0.3.3",
+                "stream-combiner": "0.0.4",
+                "through": "2.3.8"
+            }
         },
         "expand-brackets": {
             "version": "0.1.5",
             "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
             "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "is-posix-bracket": "0.1.1"
+            }
         },
         "expand-range": {
             "version": "1.8.2",
             "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
             "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "fill-range": "2.2.3"
+            }
         },
         "extend": {
             "version": "3.0.1",
@@ -499,13 +654,19 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
             "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "is-extendable": "0.1.1"
+            }
         },
         "extglob": {
             "version": "0.3.2",
             "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
             "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
             "dev": true,
+            "requires": {
+                "is-extglob": "1.0.0"
+            },
             "dependencies": {
                 "is-extglob": {
                     "version": "1.0.0",
@@ -525,13 +686,20 @@
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.3.0.tgz",
             "integrity": "sha1-Rb4X0Cu5kX1gzP/UmVyZnmyMmUg=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "chalk": "1.1.3",
+                "time-stamp": "1.1.0"
+            }
         },
         "fd-slicer": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.0.1.tgz",
             "integrity": "sha1-i1vL2ewyfFBBv5qwI/1nUPEXfmU=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "pend": "1.2.0"
+            }
         },
         "filename-regex": {
             "version": "2.0.1",
@@ -543,7 +711,14 @@
             "version": "2.2.3",
             "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
             "integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "is-number": "2.1.0",
+                "isobject": "2.1.0",
+                "randomatic": "1.1.7",
+                "repeat-element": "1.1.2",
+                "repeat-string": "1.6.1"
+            }
         },
         "first-chunk-stream": {
             "version": "1.0.0",
@@ -561,7 +736,10 @@
             "version": "0.1.5",
             "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
             "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "for-in": "1.0.2"
+            }
         },
         "forever-agent": {
             "version": "0.6.1",
@@ -573,13 +751,21 @@
             "version": "2.1.4",
             "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
             "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "asynckit": "0.4.0",
+                "combined-stream": "1.0.5",
+                "mime-types": "2.1.15"
+            }
         },
         "formatio": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/formatio/-/formatio-1.2.0.tgz",
             "integrity": "sha1-87IWfZBoxGmKjVH092CjmlTYGOs=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "samsam": "1.2.1"
+            }
         },
         "from": {
             "version": "0.1.7",
@@ -597,7 +783,13 @@
             "version": "1.0.11",
             "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
             "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "graceful-fs": "4.1.11",
+                "inherits": "2.0.3",
+                "mkdirp": "0.5.1",
+                "rimraf": "2.6.1"
+            }
         },
         "generate-function": {
             "version": "2.0.0",
@@ -609,7 +801,10 @@
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
             "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "is-property": "1.0.2"
+            }
         },
         "get-func-name": {
             "version": "2.0.0",
@@ -622,6 +817,9 @@
             "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
             "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
             "dev": true,
+            "requires": {
+                "assert-plus": "1.0.0"
+            },
             "dependencies": {
                 "assert-plus": {
                     "version": "1.0.0",
@@ -641,25 +839,45 @@
             "version": "1.9.1",
             "resolved": "https://registry.npmjs.org/git-rev-sync/-/git-rev-sync-1.9.1.tgz",
             "integrity": "sha1-oMLj3TkqvPa3aWLif8dfsyI0Sc4=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "escape-string-regexp": "1.0.5",
+                "graceful-fs": "4.1.11",
+                "shelljs": "0.7.7"
+            }
         },
         "glob": {
             "version": "7.1.2",
             "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
             "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "fs.realpath": "1.0.0",
+                "inflight": "1.0.6",
+                "inherits": "2.0.3",
+                "minimatch": "3.0.4",
+                "once": "1.4.0",
+                "path-is-absolute": "1.0.1"
+            }
         },
         "glob-base": {
             "version": "0.3.0",
             "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
             "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
             "dev": true,
+            "requires": {
+                "glob-parent": "2.0.0",
+                "is-glob": "2.0.1"
+            },
             "dependencies": {
                 "glob-parent": {
                     "version": "2.0.0",
                     "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
                     "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "is-glob": "2.0.1"
+                    }
                 },
                 "is-extglob": {
                     "version": "1.0.0",
@@ -671,7 +889,10 @@
                     "version": "2.0.1",
                     "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
                     "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "is-extglob": "1.0.0"
+                    }
                 }
             }
         },
@@ -679,25 +900,52 @@
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
             "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "is-glob": "3.1.0",
+                "path-dirname": "1.0.2"
+            }
         },
         "glob-stream": {
             "version": "5.3.5",
             "resolved": "https://registry.npmjs.org/glob-stream/-/glob-stream-5.3.5.tgz",
             "integrity": "sha1-pVZlqajM3EGRWofHAeMtTgFvrSI=",
             "dev": true,
+            "requires": {
+                "extend": "3.0.1",
+                "glob": "5.0.15",
+                "glob-parent": "3.1.0",
+                "micromatch": "2.3.11",
+                "ordered-read-streams": "0.3.0",
+                "through2": "0.6.5",
+                "to-absolute-glob": "0.1.1",
+                "unique-stream": "2.2.1"
+            },
             "dependencies": {
                 "glob": {
                     "version": "5.0.15",
                     "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
                     "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "inflight": "1.0.6",
+                        "inherits": "2.0.3",
+                        "minimatch": "3.0.4",
+                        "once": "1.4.0",
+                        "path-is-absolute": "1.0.1"
+                    }
                 },
                 "readable-stream": {
                     "version": "1.0.34",
                     "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
                     "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "core-util-is": "1.0.2",
+                        "inherits": "2.0.3",
+                        "isarray": "0.0.1",
+                        "string_decoder": "0.10.31"
+                    }
                 },
                 "string_decoder": {
                     "version": "0.10.31",
@@ -709,7 +957,11 @@
                     "version": "0.6.5",
                     "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
                     "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "readable-stream": "1.0.34",
+                        "xtend": "4.0.1"
+                    }
                 }
             }
         },
@@ -717,7 +969,10 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/glogg/-/glogg-1.0.0.tgz",
             "integrity": "sha1-f+DxmfV6yQbPUS/urY+Q7kooT8U=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "sparkles": "1.0.0"
+            }
         },
         "graceful-fs": {
             "version": "4.1.11",
@@ -741,19 +996,33 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/gulp-chmod/-/gulp-chmod-2.0.0.tgz",
             "integrity": "sha1-AMOQuSigeZslGsz2MaoJ4BzGKZw=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "deep-assign": "1.0.0",
+                "stat-mode": "0.2.2",
+                "through2": "2.0.3"
+            }
         },
         "gulp-filter": {
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/gulp-filter/-/gulp-filter-5.0.0.tgz",
             "integrity": "sha1-z6gZZvtniE8rp1SwZxUpKUKNWbw=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "gulp-util": "3.0.8",
+                "multimatch": "2.1.0",
+                "streamfilter": "1.0.5"
+            }
         },
         "gulp-gunzip": {
             "version": "0.0.3",
             "resolved": "https://registry.npmjs.org/gulp-gunzip/-/gulp-gunzip-0.0.3.tgz",
             "integrity": "sha1-e24HsPWP09QlFcSOrVpj3wVy9i8=",
             "dev": true,
+            "requires": {
+                "through2": "0.6.5",
+                "vinyl": "0.4.6"
+            },
             "dependencies": {
                 "clone": {
                     "version": "0.2.0",
@@ -765,7 +1034,13 @@
                     "version": "1.0.34",
                     "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
                     "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "core-util-is": "1.0.2",
+                        "inherits": "2.0.3",
+                        "isarray": "0.0.1",
+                        "string_decoder": "0.10.31"
+                    }
                 },
                 "string_decoder": {
                     "version": "0.10.31",
@@ -777,13 +1052,21 @@
                     "version": "0.6.5",
                     "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
                     "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "readable-stream": "1.0.34",
+                        "xtend": "4.0.1"
+                    }
                 },
                 "vinyl": {
                     "version": "0.4.6",
                     "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
                     "integrity": "sha1-LzVsh6VQolVGHza76ypbqL94SEc=",
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "clone": "0.2.0",
+                        "clone-stats": "0.0.1"
+                    }
                 }
             }
         },
@@ -792,6 +1075,13 @@
             "resolved": "https://registry.npmjs.org/gulp-remote-src/-/gulp-remote-src-0.4.2.tgz",
             "integrity": "sha1-zrN3DjREMo1hOG+6qrIAvBHNmKg=",
             "dev": true,
+            "requires": {
+                "event-stream": "3.3.4",
+                "node.extend": "1.1.6",
+                "request": "2.79.0",
+                "through2": "2.0.3",
+                "vinyl": "2.0.2"
+            },
             "dependencies": {
                 "caseless": {
                     "version": "0.11.0",
@@ -809,7 +1099,13 @@
                     "version": "2.0.6",
                     "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
                     "integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "chalk": "1.1.3",
+                        "commander": "2.11.0",
+                        "is-my-json-valid": "2.16.0",
+                        "pinkie-promise": "2.0.1"
+                    }
                 },
                 "qs": {
                     "version": "6.3.2",
@@ -827,7 +1123,29 @@
                     "version": "2.79.0",
                     "resolved": "https://registry.npmjs.org/request/-/request-2.79.0.tgz",
                     "integrity": "sha1-Tf5b9r6LjNw3/Pk+BLZVd3InEN4=",
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "aws-sign2": "0.6.0",
+                        "aws4": "1.6.0",
+                        "caseless": "0.11.0",
+                        "combined-stream": "1.0.5",
+                        "extend": "3.0.1",
+                        "forever-agent": "0.6.1",
+                        "form-data": "2.1.4",
+                        "har-validator": "2.0.6",
+                        "hawk": "3.1.3",
+                        "http-signature": "1.1.1",
+                        "is-typedarray": "1.0.0",
+                        "isstream": "0.1.2",
+                        "json-stringify-safe": "5.0.1",
+                        "mime-types": "2.1.15",
+                        "oauth-sign": "0.8.2",
+                        "qs": "6.3.2",
+                        "stringstream": "0.0.5",
+                        "tough-cookie": "2.3.2",
+                        "tunnel-agent": "0.4.3",
+                        "uuid": "3.1.0"
+                    }
                 },
                 "tunnel-agent": {
                     "version": "0.4.3",
@@ -839,7 +1157,16 @@
                     "version": "2.0.2",
                     "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.0.2.tgz",
                     "integrity": "sha1-CjcT2NTpIhxY8QyhbAEWyeJe2nw=",
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "clone": "1.0.2",
+                        "clone-buffer": "1.0.0",
+                        "clone-stats": "1.0.0",
+                        "cloneable-readable": "1.0.0",
+                        "is-stream": "1.1.0",
+                        "remove-trailing-separator": "1.0.2",
+                        "replace-ext": "1.0.0"
+                    }
                 }
             }
         },
@@ -848,12 +1175,24 @@
             "resolved": "https://registry.npmjs.org/gulp-sourcemaps/-/gulp-sourcemaps-1.6.0.tgz",
             "integrity": "sha1-uG/zSdgBzrVuHZ59x7vLS33uYAw=",
             "dev": true,
+            "requires": {
+                "convert-source-map": "1.5.0",
+                "graceful-fs": "4.1.11",
+                "strip-bom": "2.0.0",
+                "through2": "2.0.3",
+                "vinyl": "1.2.0"
+            },
             "dependencies": {
                 "vinyl": {
                     "version": "1.2.0",
                     "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
                     "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "clone": "1.0.2",
+                        "clone-stats": "0.0.1",
+                        "replace-ext": "0.0.1"
+                    }
                 }
             }
         },
@@ -861,19 +1200,52 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/gulp-symdest/-/gulp-symdest-1.1.0.tgz",
             "integrity": "sha1-wWUyBzLRks5W/ZQnH/oSMjS/KuA=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "event-stream": "3.3.4",
+                "mkdirp": "0.5.1",
+                "queue": "3.1.0",
+                "vinyl-fs": "2.4.4"
+            }
         },
         "gulp-untar": {
             "version": "0.0.6",
             "resolved": "https://registry.npmjs.org/gulp-untar/-/gulp-untar-0.0.6.tgz",
             "integrity": "sha1-1r3v3n6ajgVMnxYjhaB4LEvnQAA=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "event-stream": "3.3.4",
+                "gulp-util": "3.0.8",
+                "streamifier": "0.1.1",
+                "tar": "2.2.1",
+                "through2": "2.0.3"
+            }
         },
         "gulp-util": {
             "version": "3.0.8",
             "resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.8.tgz",
             "integrity": "sha1-AFTh50RQLifATBh8PsxQXdVLu08=",
             "dev": true,
+            "requires": {
+                "array-differ": "1.0.0",
+                "array-uniq": "1.0.3",
+                "beeper": "1.1.1",
+                "chalk": "1.1.3",
+                "dateformat": "2.0.0",
+                "fancy-log": "1.3.0",
+                "gulplog": "1.0.0",
+                "has-gulplog": "0.1.0",
+                "lodash._reescape": "3.0.0",
+                "lodash._reevaluate": "3.0.0",
+                "lodash._reinterpolate": "3.0.0",
+                "lodash.template": "3.6.2",
+                "minimist": "1.2.0",
+                "multipipe": "0.1.2",
+                "object-assign": "3.0.0",
+                "replace-ext": "0.0.1",
+                "through2": "2.0.3",
+                "vinyl": "0.5.3"
+            },
             "dependencies": {
                 "minimist": {
                     "version": "1.2.0",
@@ -888,6 +1260,15 @@
             "resolved": "https://registry.npmjs.org/gulp-vinyl-zip/-/gulp-vinyl-zip-1.4.0.tgz",
             "integrity": "sha1-VjgvLMtXIxuwR4x4c3zNVylzvuE=",
             "dev": true,
+            "requires": {
+                "event-stream": "3.3.4",
+                "queue": "3.1.0",
+                "through2": "0.6.5",
+                "vinyl": "0.4.6",
+                "vinyl-fs": "2.4.4",
+                "yauzl": "2.8.0",
+                "yazl": "2.4.2"
+            },
             "dependencies": {
                 "clone": {
                     "version": "0.2.0",
@@ -899,7 +1280,13 @@
                     "version": "1.0.34",
                     "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
                     "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "core-util-is": "1.0.2",
+                        "inherits": "2.0.3",
+                        "isarray": "0.0.1",
+                        "string_decoder": "0.10.31"
+                    }
                 },
                 "string_decoder": {
                     "version": "0.10.31",
@@ -911,13 +1298,21 @@
                     "version": "0.6.5",
                     "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
                     "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "readable-stream": "1.0.34",
+                        "xtend": "4.0.1"
+                    }
                 },
                 "vinyl": {
                     "version": "0.4.6",
                     "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
                     "integrity": "sha1-LzVsh6VQolVGHza76ypbqL94SEc=",
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "clone": "0.2.0",
+                        "clone-stats": "0.0.1"
+                    }
                 }
             }
         },
@@ -925,7 +1320,10 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/gulplog/-/gulplog-1.0.0.tgz",
             "integrity": "sha1-4oxNRdBey77YGDY86PnFkmIp/+U=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "glogg": "1.0.0"
+            }
         },
         "har-schema": {
             "version": "1.0.5",
@@ -937,13 +1335,20 @@
             "version": "4.2.1",
             "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
             "integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "ajv": "4.11.8",
+                "har-schema": "1.0.5"
+            }
         },
         "has-ansi": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
             "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "ansi-regex": "2.1.1"
+            }
         },
         "has-flag": {
             "version": "1.0.0",
@@ -955,13 +1360,22 @@
             "version": "0.1.0",
             "resolved": "https://registry.npmjs.org/has-gulplog/-/has-gulplog-0.1.0.tgz",
             "integrity": "sha1-ZBTIKRNpfaUVkDl9r7EvIpZ4Ec4=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "sparkles": "1.0.0"
+            }
         },
         "hawk": {
             "version": "3.1.3",
             "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
             "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "boom": "2.10.1",
+                "cryptiles": "2.0.5",
+                "hoek": "2.16.3",
+                "sntp": "1.0.9"
+            }
         },
         "hoek": {
             "version": "2.16.3",
@@ -973,13 +1387,22 @@
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
             "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "assert-plus": "0.2.0",
+                "jsprim": "1.4.0",
+                "sshpk": "1.13.1"
+            }
         },
         "inflight": {
             "version": "1.0.6",
             "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
             "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "once": "1.4.0",
+                "wrappy": "1.0.2"
+            }
         },
         "inherits": {
             "version": "2.0.3",
@@ -1015,7 +1438,10 @@
             "version": "0.1.3",
             "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
             "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "is-primitive": "2.0.0"
+            }
         },
         "is-extendable": {
             "version": "0.1.1",
@@ -1033,19 +1459,31 @@
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
             "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "is-extglob": "2.1.1"
+            }
         },
         "is-my-json-valid": {
             "version": "2.16.0",
             "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.16.0.tgz",
             "integrity": "sha1-8Hndm/2uZe4gOKrorLyGqxCeNpM=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "generate-function": "2.0.0",
+                "generate-object-property": "1.2.0",
+                "jsonpointer": "4.0.1",
+                "xtend": "4.0.1"
+            }
         },
         "is-number": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
             "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "kind-of": "3.2.2"
+            }
         },
         "is-obj": {
             "version": "1.0.1",
@@ -1106,6 +1544,9 @@
             "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
             "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
             "dev": true,
+            "requires": {
+                "isarray": "1.0.0"
+            },
             "dependencies": {
                 "isarray": {
                     "version": "1.0.0",
@@ -1122,9 +1563,9 @@
             "dev": true
         },
         "js-tokens": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz",
-            "integrity": "sha1-COnxMkhKLEWjCQfp3E1VZ7fxFNc=",
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+            "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
             "dev": true
         },
         "jsbn": {
@@ -1144,7 +1585,10 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
             "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "jsonify": "0.0.0"
+            }
         },
         "json-stringify-safe": {
             "version": "5.0.1",
@@ -1175,6 +1619,12 @@
             "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.0.tgz",
             "integrity": "sha1-o7h+QCmNjDgFUtjMdiigu5WiKRg=",
             "dev": true,
+            "requires": {
+                "assert-plus": "1.0.0",
+                "extsprintf": "1.0.2",
+                "json-schema": "0.2.3",
+                "verror": "1.3.6"
+            },
             "dependencies": {
                 "assert-plus": {
                     "version": "1.0.0",
@@ -1188,13 +1638,19 @@
             "version": "3.2.2",
             "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
             "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "is-buffer": "1.1.5"
+            }
         },
         "lazystream": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.0.tgz",
             "integrity": "sha1-9plf4PggOS9hOWvolGJAe7dxaOQ=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "readable-stream": "2.3.3"
+            }
         },
         "lodash": {
             "version": "4.17.4",
@@ -1205,7 +1661,11 @@
             "version": "3.2.0",
             "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
             "integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "lodash._basecopy": "3.0.1",
+                "lodash.keys": "3.1.2"
+            }
         },
         "lodash._basecopy": {
             "version": "3.0.1",
@@ -1271,13 +1731,21 @@
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/lodash.create/-/lodash.create-3.1.1.tgz",
             "integrity": "sha1-1/KEnw29p+BGgruM1yqwIkYd6+c=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "lodash._baseassign": "3.2.0",
+                "lodash._basecreate": "3.0.3",
+                "lodash._isiterateecall": "3.0.9"
+            }
         },
         "lodash.escape": {
             "version": "3.2.0",
             "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-3.2.0.tgz",
             "integrity": "sha1-mV7g3BjBtIzJLv+ucaEKq1tIdpg=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "lodash._root": "3.0.1"
+            }
         },
         "lodash.isarguments": {
             "version": "3.1.0",
@@ -1301,7 +1769,12 @@
             "version": "3.1.2",
             "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
             "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "lodash._getnative": "3.9.1",
+                "lodash.isarguments": "3.1.0",
+                "lodash.isarray": "3.0.4"
+            }
         },
         "lodash.restparam": {
             "version": "3.6.1",
@@ -1313,13 +1786,28 @@
             "version": "3.6.2",
             "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-3.6.2.tgz",
             "integrity": "sha1-+M3sxhaaJVvpCYrosMU9N4kx0U8=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "lodash._basecopy": "3.0.1",
+                "lodash._basetostring": "3.0.1",
+                "lodash._basevalues": "3.0.0",
+                "lodash._isiterateecall": "3.0.9",
+                "lodash._reinterpolate": "3.0.0",
+                "lodash.escape": "3.2.0",
+                "lodash.keys": "3.1.2",
+                "lodash.restparam": "3.6.1",
+                "lodash.templatesettings": "3.1.1"
+            }
         },
         "lodash.templatesettings": {
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-3.1.1.tgz",
             "integrity": "sha1-+zB4RHU7Zrnxr6VOJix0UwfbqOU=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "lodash._reinterpolate": "3.0.0",
+                "lodash.escape": "3.2.0"
+            }
         },
         "lolex": {
             "version": "1.6.0",
@@ -1337,13 +1825,31 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-1.0.1.tgz",
             "integrity": "sha1-QEEgLVCKNCugAXQAjfDCUbjBNeE=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "readable-stream": "2.3.3"
+            }
         },
         "micromatch": {
             "version": "2.3.11",
             "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
             "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
             "dev": true,
+            "requires": {
+                "arr-diff": "2.0.0",
+                "array-unique": "0.2.1",
+                "braces": "1.8.5",
+                "expand-brackets": "0.1.5",
+                "extglob": "0.3.2",
+                "filename-regex": "2.0.1",
+                "is-extglob": "1.0.0",
+                "is-glob": "2.0.1",
+                "kind-of": "3.2.2",
+                "normalize-path": "2.1.1",
+                "object.omit": "2.0.1",
+                "parse-glob": "3.0.4",
+                "regex-cache": "0.4.3"
+            },
             "dependencies": {
                 "is-extglob": {
                     "version": "1.0.0",
@@ -1355,7 +1861,10 @@
                     "version": "2.0.1",
                     "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
                     "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "is-extglob": "1.0.0"
+                    }
                 }
             }
         },
@@ -1369,13 +1878,19 @@
             "version": "2.1.15",
             "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz",
             "integrity": "sha1-pOv1BkCUVpI3uM9wBGd20J/JKu0=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "mime-db": "1.27.0"
+            }
         },
         "minimatch": {
             "version": "3.0.4",
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
             "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "brace-expansion": "1.1.8"
+            }
         },
         "minimist": {
             "version": "0.0.8",
@@ -1387,32 +1902,68 @@
             "version": "0.5.1",
             "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
             "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "minimist": "0.0.8"
+            }
         },
         "mocha": {
             "version": "3.4.2",
             "resolved": "https://registry.npmjs.org/mocha/-/mocha-3.4.2.tgz",
             "integrity": "sha1-0O9NMyEm2/GNDWQMmzgt1IvpdZQ=",
             "dev": true,
+            "requires": {
+                "browser-stdout": "1.3.0",
+                "commander": "2.9.0",
+                "debug": "2.6.0",
+                "diff": "3.2.0",
+                "escape-string-regexp": "1.0.5",
+                "glob": "7.1.1",
+                "growl": "1.9.2",
+                "json3": "3.3.2",
+                "lodash.create": "3.1.1",
+                "mkdirp": "0.5.1",
+                "supports-color": "3.1.2"
+            },
             "dependencies": {
+                "commander": {
+                    "version": "2.9.0",
+                    "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+                    "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
+                    "dev": true,
+                    "requires": {
+                        "graceful-readlink": "1.0.1"
+                    }
+                },
                 "glob": {
                     "version": "7.1.1",
                     "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
                     "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "fs.realpath": "1.0.0",
+                        "inflight": "1.0.6",
+                        "inherits": "2.0.3",
+                        "minimatch": "3.0.4",
+                        "once": "1.4.0",
+                        "path-is-absolute": "1.0.1"
+                    }
                 },
                 "supports-color": {
                     "version": "3.1.2",
                     "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
                     "integrity": "sha1-cqJiiU2dQIuVbKBf83su2KbiotU=",
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "1.0.0"
+                    }
                 }
             }
         },
         "mockery": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/mockery/-/mockery-2.0.0.tgz",
-            "integrity": "sha1-BWmhGhhIRh/cNHz4zKLfLzEpvAM=",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/mockery/-/mockery-2.1.0.tgz",
+            "integrity": "sha512-9VkOmxKlWXoDO/h1jDZaS4lH33aWfRiJiNT/tKj+8OGzrcFDLo8d0syGdbsc3Bc4GvRXPb+NMMvojotmuGJTvA==",
             "dev": true
         },
         "ms": {
@@ -1425,13 +1976,22 @@
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/multimatch/-/multimatch-2.1.0.tgz",
             "integrity": "sha1-nHkGoi+0wCkZ4vX3UWG0zb1LKis=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "array-differ": "1.0.0",
+                "array-union": "1.0.2",
+                "arrify": "1.0.1",
+                "minimatch": "3.0.4"
+            }
         },
         "multipipe": {
             "version": "0.1.2",
             "resolved": "https://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz",
             "integrity": "sha1-Ko8t33Du1WTf8tV/HhoTfZ8FB4s=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "duplexer2": "0.0.2"
+            }
         },
         "native-promise-only": {
             "version": "0.8.1",
@@ -1443,24 +2003,64 @@
             "version": "1.1.6",
             "resolved": "https://registry.npmjs.org/node.extend/-/node.extend-1.1.6.tgz",
             "integrity": "sha1-p7iCyC1sk6SGOlUEvV3o7IYli5Y=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "is": "3.2.1"
+            }
         },
         "normalize-path": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
             "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "remove-trailing-separator": "1.0.2"
+            }
         },
         "nyc": {
-            "version": "11.0.2",
-            "resolved": "https://registry.npmjs.org/nyc/-/nyc-11.0.2.tgz",
-            "integrity": "sha512-31rRd6ME9NM17w0oPKqi51a6fzJAqYarnzQXK+iL8XaX+3H6VH0BQut7qHIgrv2mBASRic4oNi2KRgcbFODrsQ==",
+            "version": "11.0.3",
+            "resolved": "https://registry.npmjs.org/nyc/-/nyc-11.0.3.tgz",
+            "integrity": "sha1-DCi8ZpqFFiFwm/eghQMDS+44ErY=",
             "dev": true,
+            "requires": {
+                "archy": "1.0.0",
+                "arrify": "1.0.1",
+                "caching-transform": "1.0.1",
+                "convert-source-map": "1.5.0",
+                "debug-log": "1.0.1",
+                "default-require-extensions": "1.0.0",
+                "find-cache-dir": "0.1.1",
+                "find-up": "2.1.0",
+                "foreground-child": "1.5.6",
+                "glob": "7.1.2",
+                "istanbul-lib-coverage": "1.1.1",
+                "istanbul-lib-hook": "1.0.7",
+                "istanbul-lib-instrument": "1.7.3",
+                "istanbul-lib-report": "1.1.1",
+                "istanbul-lib-source-maps": "1.2.1",
+                "istanbul-reports": "1.1.1",
+                "md5-hex": "1.3.0",
+                "merge-source-map": "1.0.4",
+                "micromatch": "2.3.11",
+                "mkdirp": "0.5.1",
+                "resolve-from": "2.0.0",
+                "rimraf": "2.6.1",
+                "signal-exit": "3.0.2",
+                "spawn-wrap": "1.3.7",
+                "test-exclude": "4.1.1",
+                "yargs": "8.0.2",
+                "yargs-parser": "5.0.0"
+            },
             "dependencies": {
                 "align-text": {
                     "version": "0.1.4",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "kind-of": "3.2.2",
+                        "longest": "1.0.1",
+                        "repeat-string": "1.6.1"
+                    }
                 },
                 "amdefine": {
                     "version": "1.0.1",
@@ -1480,7 +2080,10 @@
                 "append-transform": {
                     "version": "0.4.0",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "default-require-extensions": "1.0.0"
+                    }
                 },
                 "archy": {
                     "version": "1.0.0",
@@ -1490,7 +2093,10 @@
                 "arr-diff": {
                     "version": "2.0.0",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "arr-flatten": "1.0.3"
+                    }
                 },
                 "arr-flatten": {
                     "version": "1.0.3",
@@ -1515,57 +2121,112 @@
                 "babel-code-frame": {
                     "version": "6.22.0",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "chalk": "1.1.3",
+                        "esutils": "2.0.2",
+                        "js-tokens": "3.0.1"
+                    }
                 },
                 "babel-generator": {
-                    "version": "6.24.1",
+                    "version": "6.25.0",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "babel-messages": "6.23.0",
+                        "babel-runtime": "6.23.0",
+                        "babel-types": "6.25.0",
+                        "detect-indent": "4.0.0",
+                        "jsesc": "1.3.0",
+                        "lodash": "4.17.4",
+                        "source-map": "0.5.6",
+                        "trim-right": "1.0.1"
+                    }
                 },
                 "babel-messages": {
                     "version": "6.23.0",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "babel-runtime": "6.23.0"
+                    }
                 },
                 "babel-runtime": {
                     "version": "6.23.0",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "core-js": "2.4.1",
+                        "regenerator-runtime": "0.10.5"
+                    }
                 },
                 "babel-template": {
-                    "version": "6.24.1",
+                    "version": "6.25.0",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "babel-runtime": "6.23.0",
+                        "babel-traverse": "6.25.0",
+                        "babel-types": "6.25.0",
+                        "babylon": "6.17.4",
+                        "lodash": "4.17.4"
+                    }
                 },
                 "babel-traverse": {
-                    "version": "6.24.1",
+                    "version": "6.25.0",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "babel-code-frame": "6.22.0",
+                        "babel-messages": "6.23.0",
+                        "babel-runtime": "6.23.0",
+                        "babel-types": "6.25.0",
+                        "babylon": "6.17.4",
+                        "debug": "2.6.8",
+                        "globals": "9.18.0",
+                        "invariant": "2.2.2",
+                        "lodash": "4.17.4"
+                    }
                 },
                 "babel-types": {
-                    "version": "6.24.1",
+                    "version": "6.25.0",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "babel-runtime": "6.23.0",
+                        "esutils": "2.0.2",
+                        "lodash": "4.17.4",
+                        "to-fast-properties": "1.0.3"
+                    }
                 },
                 "babylon": {
-                    "version": "6.17.2",
+                    "version": "6.17.4",
                     "bundled": true,
                     "dev": true
                 },
                 "balanced-match": {
-                    "version": "0.4.2",
+                    "version": "1.0.0",
                     "bundled": true,
                     "dev": true
                 },
                 "brace-expansion": {
-                    "version": "1.1.7",
+                    "version": "1.1.8",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "balanced-match": "1.0.0",
+                        "concat-map": "0.0.1"
+                    }
                 },
                 "braces": {
                     "version": "1.8.5",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "expand-range": "1.8.2",
+                        "preserve": "0.2.0",
+                        "repeat-element": "1.1.2"
+                    }
                 },
                 "builtin-modules": {
                     "version": "1.1.1",
@@ -1575,24 +2236,51 @@
                 "caching-transform": {
                     "version": "1.0.1",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "md5-hex": "1.3.0",
+                        "mkdirp": "0.5.1",
+                        "write-file-atomic": "1.3.4"
+                    }
+                },
+                "camelcase": {
+                    "version": "1.2.1",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
                 },
                 "center-align": {
                     "version": "0.1.3",
                     "bundled": true,
                     "dev": true,
-                    "optional": true
+                    "optional": true,
+                    "requires": {
+                        "align-text": "0.1.4",
+                        "lazy-cache": "1.0.4"
+                    }
                 },
                 "chalk": {
                     "version": "1.1.3",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "2.2.1",
+                        "escape-string-regexp": "1.0.5",
+                        "has-ansi": "2.0.0",
+                        "strip-ansi": "3.0.1",
+                        "supports-color": "2.0.0"
+                    }
                 },
                 "cliui": {
                     "version": "2.1.0",
                     "bundled": true,
                     "dev": true,
                     "optional": true,
+                    "requires": {
+                        "center-align": "0.1.3",
+                        "right-align": "0.1.3",
+                        "wordwrap": "0.0.2"
+                    },
                     "dependencies": {
                         "wordwrap": {
                             "version": "0.0.2",
@@ -1630,12 +2318,19 @@
                 "cross-spawn": {
                     "version": "4.0.2",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "lru-cache": "4.1.1",
+                        "which": "1.2.14"
+                    }
                 },
                 "debug": {
                     "version": "2.6.8",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "ms": "2.0.0"
+                    }
                 },
                 "debug-log": {
                     "version": "1.0.1",
@@ -1650,17 +2345,26 @@
                 "default-require-extensions": {
                     "version": "1.0.0",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "strip-bom": "2.0.0"
+                    }
                 },
                 "detect-indent": {
                     "version": "4.0.0",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "repeating": "2.0.1"
+                    }
                 },
                 "error-ex": {
                     "version": "1.3.1",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "is-arrayish": "0.2.1"
+                    }
                 },
                 "escape-string-regexp": {
                     "version": "1.0.5",
@@ -1675,22 +2379,40 @@
                 "execa": {
                     "version": "0.5.1",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "cross-spawn": "4.0.2",
+                        "get-stream": "2.3.1",
+                        "is-stream": "1.1.0",
+                        "npm-run-path": "2.0.2",
+                        "p-finally": "1.0.0",
+                        "signal-exit": "3.0.2",
+                        "strip-eof": "1.0.0"
+                    }
                 },
                 "expand-brackets": {
                     "version": "0.1.5",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "is-posix-bracket": "0.1.1"
+                    }
                 },
                 "expand-range": {
                     "version": "1.8.2",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "fill-range": "2.2.3"
+                    }
                 },
                 "extglob": {
                     "version": "0.3.2",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "is-extglob": "1.0.0"
+                    }
                 },
                 "filename-regex": {
                     "version": "2.0.1",
@@ -1700,17 +2422,32 @@
                 "fill-range": {
                     "version": "2.2.3",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "is-number": "2.1.0",
+                        "isobject": "2.1.0",
+                        "randomatic": "1.1.7",
+                        "repeat-element": "1.1.2",
+                        "repeat-string": "1.6.1"
+                    }
                 },
                 "find-cache-dir": {
                     "version": "0.1.1",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "commondir": "1.0.1",
+                        "mkdirp": "0.5.1",
+                        "pkg-dir": "1.0.0"
+                    }
                 },
                 "find-up": {
                     "version": "2.1.0",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "locate-path": "2.0.0"
+                    }
                 },
                 "for-in": {
                     "version": "1.0.2",
@@ -1720,12 +2457,19 @@
                 "for-own": {
                     "version": "0.1.5",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "for-in": "1.0.2"
+                    }
                 },
                 "foreground-child": {
                     "version": "1.5.6",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "cross-spawn": "4.0.2",
+                        "signal-exit": "3.0.2"
+                    }
                 },
                 "fs.realpath": {
                     "version": "1.0.0",
@@ -1740,25 +2484,44 @@
                 "get-stream": {
                     "version": "2.3.1",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "object-assign": "4.1.1",
+                        "pinkie-promise": "2.0.1"
+                    }
                 },
                 "glob": {
                     "version": "7.1.2",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "fs.realpath": "1.0.0",
+                        "inflight": "1.0.6",
+                        "inherits": "2.0.3",
+                        "minimatch": "3.0.4",
+                        "once": "1.4.0",
+                        "path-is-absolute": "1.0.1"
+                    }
                 },
                 "glob-base": {
                     "version": "0.3.0",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "glob-parent": "2.0.0",
+                        "is-glob": "2.0.1"
+                    }
                 },
                 "glob-parent": {
                     "version": "2.0.0",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "is-glob": "2.0.1"
+                    }
                 },
                 "globals": {
-                    "version": "9.17.0",
+                    "version": "9.18.0",
                     "bundled": true,
                     "dev": true
                 },
@@ -1771,18 +2534,30 @@
                     "version": "4.0.10",
                     "bundled": true,
                     "dev": true,
+                    "requires": {
+                        "async": "1.5.2",
+                        "optimist": "0.6.1",
+                        "source-map": "0.4.4",
+                        "uglify-js": "2.8.29"
+                    },
                     "dependencies": {
                         "source-map": {
                             "version": "0.4.4",
                             "bundled": true,
-                            "dev": true
+                            "dev": true,
+                            "requires": {
+                                "amdefine": "1.0.1"
+                            }
                         }
                     }
                 },
                 "has-ansi": {
                     "version": "2.0.0",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "2.1.1"
+                    }
                 },
                 "has-flag": {
                     "version": "1.0.0",
@@ -1802,7 +2577,11 @@
                 "inflight": {
                     "version": "1.0.6",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "once": "1.4.0",
+                        "wrappy": "1.0.2"
+                    }
                 },
                 "inherits": {
                     "version": "2.0.3",
@@ -1812,7 +2591,10 @@
                 "invariant": {
                     "version": "2.2.2",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "loose-envify": "1.3.1"
+                    }
                 },
                 "invert-kv": {
                     "version": "1.0.0",
@@ -1832,7 +2614,10 @@
                 "is-builtin-module": {
                     "version": "1.0.0",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "builtin-modules": "1.1.1"
+                    }
                 },
                 "is-dotfile": {
                     "version": "1.0.3",
@@ -1842,7 +2627,10 @@
                 "is-equal-shallow": {
                     "version": "0.1.3",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "is-primitive": "2.0.0"
+                    }
                 },
                 "is-extendable": {
                     "version": "0.1.1",
@@ -1857,22 +2645,34 @@
                 "is-finite": {
                     "version": "1.0.2",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "number-is-nan": "1.0.1"
+                    }
                 },
                 "is-fullwidth-code-point": {
                     "version": "1.0.0",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "number-is-nan": "1.0.1"
+                    }
                 },
                 "is-glob": {
                     "version": "2.0.1",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "is-extglob": "1.0.0"
+                    }
                 },
                 "is-number": {
                     "version": "2.1.0",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "kind-of": "3.2.2"
+                    }
                 },
                 "is-posix-bracket": {
                     "version": "0.1.1",
@@ -1907,7 +2707,10 @@
                 "isobject": {
                     "version": "2.1.0",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "isarray": "1.0.0"
+                    }
                 },
                 "istanbul-lib-coverage": {
                     "version": "1.1.1",
@@ -1917,34 +2720,65 @@
                 "istanbul-lib-hook": {
                     "version": "1.0.7",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "append-transform": "0.4.0"
+                    }
                 },
                 "istanbul-lib-instrument": {
-                    "version": "1.7.2",
+                    "version": "1.7.3",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "babel-generator": "6.25.0",
+                        "babel-template": "6.25.0",
+                        "babel-traverse": "6.25.0",
+                        "babel-types": "6.25.0",
+                        "babylon": "6.17.4",
+                        "istanbul-lib-coverage": "1.1.1",
+                        "semver": "5.3.0"
+                    }
                 },
                 "istanbul-lib-report": {
                     "version": "1.1.1",
                     "bundled": true,
                     "dev": true,
+                    "requires": {
+                        "istanbul-lib-coverage": "1.1.1",
+                        "mkdirp": "0.5.1",
+                        "path-parse": "1.0.5",
+                        "supports-color": "3.2.3"
+                    },
                     "dependencies": {
                         "supports-color": {
                             "version": "3.2.3",
                             "bundled": true,
-                            "dev": true
+                            "dev": true,
+                            "requires": {
+                                "has-flag": "1.0.0"
+                            }
                         }
                     }
                 },
                 "istanbul-lib-source-maps": {
                     "version": "1.2.1",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "debug": "2.6.8",
+                        "istanbul-lib-coverage": "1.1.1",
+                        "mkdirp": "0.5.1",
+                        "rimraf": "2.6.1",
+                        "source-map": "0.5.6"
+                    }
                 },
                 "istanbul-reports": {
                     "version": "1.1.1",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "handlebars": "4.0.10"
+                    }
                 },
                 "js-tokens": {
                     "version": "3.0.1",
@@ -1959,7 +2793,10 @@
                 "kind-of": {
                     "version": "3.2.2",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "is-buffer": "1.1.5"
+                    }
                 },
                 "lazy-cache": {
                     "version": "1.0.4",
@@ -1970,17 +2807,31 @@
                 "lcid": {
                     "version": "1.0.0",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "invert-kv": "1.0.0"
+                    }
                 },
                 "load-json-file": {
                     "version": "1.1.0",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "graceful-fs": "4.1.11",
+                        "parse-json": "2.2.0",
+                        "pify": "2.3.0",
+                        "pinkie-promise": "2.0.1",
+                        "strip-bom": "2.0.0"
+                    }
                 },
                 "locate-path": {
                     "version": "2.0.0",
                     "bundled": true,
                     "dev": true,
+                    "requires": {
+                        "p-locate": "2.0.0",
+                        "path-exists": "3.0.0"
+                    },
                     "dependencies": {
                         "path-exists": {
                             "version": "3.0.0",
@@ -2002,17 +2853,27 @@
                 "loose-envify": {
                     "version": "1.3.1",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "js-tokens": "3.0.1"
+                    }
                 },
                 "lru-cache": {
-                    "version": "4.0.2",
+                    "version": "4.1.1",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "pseudomap": "1.0.2",
+                        "yallist": "2.1.2"
+                    }
                 },
                 "md5-hex": {
                     "version": "1.3.0",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "md5-o-matic": "0.1.1"
+                    }
                 },
                 "md5-o-matic": {
                     "version": "0.1.1",
@@ -2022,17 +2883,38 @@
                 "mem": {
                     "version": "1.1.0",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "mimic-fn": "1.1.0"
+                    }
                 },
                 "merge-source-map": {
-                    "version": "1.0.3",
+                    "version": "1.0.4",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "source-map": "0.5.6"
+                    }
                 },
                 "micromatch": {
                     "version": "2.3.11",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "arr-diff": "2.0.0",
+                        "array-unique": "0.2.1",
+                        "braces": "1.8.5",
+                        "expand-brackets": "0.1.5",
+                        "extglob": "0.3.2",
+                        "filename-regex": "2.0.1",
+                        "is-extglob": "1.0.0",
+                        "is-glob": "2.0.1",
+                        "kind-of": "3.2.2",
+                        "normalize-path": "2.1.1",
+                        "object.omit": "2.0.1",
+                        "parse-glob": "3.0.4",
+                        "regex-cache": "0.4.3"
+                    }
                 },
                 "mimic-fn": {
                     "version": "1.1.0",
@@ -2042,7 +2924,10 @@
                 "minimatch": {
                     "version": "3.0.4",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "brace-expansion": "1.1.8"
+                    }
                 },
                 "minimist": {
                     "version": "0.0.8",
@@ -2052,7 +2937,10 @@
                 "mkdirp": {
                     "version": "0.5.1",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "minimist": "0.0.8"
+                    }
                 },
                 "ms": {
                     "version": "2.0.0",
@@ -2062,17 +2950,29 @@
                 "normalize-package-data": {
                     "version": "2.3.8",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "hosted-git-info": "2.4.2",
+                        "is-builtin-module": "1.0.0",
+                        "semver": "5.3.0",
+                        "validate-npm-package-license": "3.0.1"
+                    }
                 },
                 "normalize-path": {
                     "version": "2.1.1",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "remove-trailing-separator": "1.0.2"
+                    }
                 },
                 "npm-run-path": {
                     "version": "2.0.2",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "path-key": "2.0.1"
+                    }
                 },
                 "number-is-nan": {
                     "version": "1.0.1",
@@ -2087,17 +2987,28 @@
                 "object.omit": {
                     "version": "2.0.1",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "for-own": "0.1.5",
+                        "is-extendable": "0.1.1"
+                    }
                 },
                 "once": {
                     "version": "1.4.0",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "wrappy": "1.0.2"
+                    }
                 },
                 "optimist": {
                     "version": "0.6.1",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "minimist": "0.0.8",
+                        "wordwrap": "0.0.3"
+                    }
                 },
                 "os-homedir": {
                     "version": "1.0.2",
@@ -2107,7 +3018,12 @@
                 "os-locale": {
                     "version": "2.0.0",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "execa": "0.5.1",
+                        "lcid": "1.0.0",
+                        "mem": "1.1.0"
+                    }
                 },
                 "p-finally": {
                     "version": "1.0.0",
@@ -2122,22 +3038,37 @@
                 "p-locate": {
                     "version": "2.0.0",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "p-limit": "1.1.0"
+                    }
                 },
                 "parse-glob": {
                     "version": "3.0.4",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "glob-base": "0.3.0",
+                        "is-dotfile": "1.0.3",
+                        "is-extglob": "1.0.0",
+                        "is-glob": "2.0.1"
+                    }
                 },
                 "parse-json": {
                     "version": "2.2.0",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "error-ex": "1.3.1"
+                    }
                 },
                 "path-exists": {
                     "version": "2.1.0",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "pinkie-promise": "2.0.1"
+                    }
                 },
                 "path-is-absolute": {
                     "version": "1.0.1",
@@ -2157,7 +3088,12 @@
                 "path-type": {
                     "version": "1.1.0",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "graceful-fs": "4.1.11",
+                        "pify": "2.3.0",
+                        "pinkie-promise": "2.0.1"
+                    }
                 },
                 "pify": {
                     "version": "2.3.0",
@@ -2172,17 +3108,27 @@
                 "pinkie-promise": {
                     "version": "2.0.1",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "pinkie": "2.0.4"
+                    }
                 },
                 "pkg-dir": {
                     "version": "1.0.0",
                     "bundled": true,
                     "dev": true,
+                    "requires": {
+                        "find-up": "1.1.2"
+                    },
                     "dependencies": {
                         "find-up": {
                             "version": "1.1.2",
                             "bundled": true,
-                            "dev": true
+                            "dev": true,
+                            "requires": {
+                                "path-exists": "2.1.0",
+                                "pinkie-promise": "2.0.1"
+                            }
                         }
                     }
                 },
@@ -2197,24 +3143,69 @@
                     "dev": true
                 },
                 "randomatic": {
-                    "version": "1.1.6",
+                    "version": "1.1.7",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "is-number": "3.0.0",
+                        "kind-of": "4.0.0"
+                    },
+                    "dependencies": {
+                        "is-number": {
+                            "version": "3.0.0",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "kind-of": "3.2.2"
+                            },
+                            "dependencies": {
+                                "kind-of": {
+                                    "version": "3.2.2",
+                                    "bundled": true,
+                                    "dev": true,
+                                    "requires": {
+                                        "is-buffer": "1.1.5"
+                                    }
+                                }
+                            }
+                        },
+                        "kind-of": {
+                            "version": "4.0.0",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "is-buffer": "1.1.5"
+                            }
+                        }
+                    }
                 },
                 "read-pkg": {
                     "version": "1.1.0",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "load-json-file": "1.1.0",
+                        "normalize-package-data": "2.3.8",
+                        "path-type": "1.1.0"
+                    }
                 },
                 "read-pkg-up": {
                     "version": "1.0.1",
                     "bundled": true,
                     "dev": true,
+                    "requires": {
+                        "find-up": "1.1.2",
+                        "read-pkg": "1.1.0"
+                    },
                     "dependencies": {
                         "find-up": {
                             "version": "1.1.2",
                             "bundled": true,
-                            "dev": true
+                            "dev": true,
+                            "requires": {
+                                "path-exists": "2.1.0",
+                                "pinkie-promise": "2.0.1"
+                            }
                         }
                     }
                 },
@@ -2226,10 +3217,14 @@
                 "regex-cache": {
                     "version": "0.4.3",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "is-equal-shallow": "0.1.3",
+                        "is-primitive": "2.0.0"
+                    }
                 },
                 "remove-trailing-separator": {
-                    "version": "1.0.1",
+                    "version": "1.0.2",
                     "bundled": true,
                     "dev": true
                 },
@@ -2246,7 +3241,10 @@
                 "repeating": {
                     "version": "2.0.1",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "is-finite": "1.0.2"
+                    }
                 },
                 "require-directory": {
                     "version": "2.1.1",
@@ -2267,12 +3265,18 @@
                     "version": "0.1.3",
                     "bundled": true,
                     "dev": true,
-                    "optional": true
+                    "optional": true,
+                    "requires": {
+                        "align-text": "0.1.4"
+                    }
                 },
                 "rimraf": {
                     "version": "2.6.1",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "glob": "7.1.2"
+                    }
                 },
                 "semver": {
                     "version": "5.3.0",
@@ -2300,14 +3304,25 @@
                     "dev": true
                 },
                 "spawn-wrap": {
-                    "version": "1.3.6",
+                    "version": "1.3.7",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "foreground-child": "1.5.6",
+                        "mkdirp": "0.5.1",
+                        "os-homedir": "1.0.2",
+                        "rimraf": "2.6.1",
+                        "signal-exit": "3.0.2",
+                        "which": "1.2.14"
+                    }
                 },
                 "spdx-correct": {
                     "version": "1.0.2",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "spdx-license-ids": "1.2.2"
+                    }
                 },
                 "spdx-expression-parse": {
                     "version": "1.0.4",
@@ -2323,6 +3338,10 @@
                     "version": "2.0.0",
                     "bundled": true,
                     "dev": true,
+                    "requires": {
+                        "is-fullwidth-code-point": "2.0.0",
+                        "strip-ansi": "3.0.1"
+                    },
                     "dependencies": {
                         "is-fullwidth-code-point": {
                             "version": "2.0.0",
@@ -2334,12 +3353,18 @@
                 "strip-ansi": {
                     "version": "3.0.1",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "2.1.1"
+                    }
                 },
                 "strip-bom": {
                     "version": "2.0.0",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "is-utf8": "0.2.1"
+                    }
                 },
                 "strip-eof": {
                     "version": "1.0.0",
@@ -2354,7 +3379,14 @@
                 "test-exclude": {
                     "version": "4.1.1",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "arrify": "1.0.1",
+                        "micromatch": "2.3.11",
+                        "object-assign": "4.1.1",
+                        "read-pkg-up": "1.0.1",
+                        "require-main-filename": "1.0.1"
+                    }
                 },
                 "to-fast-properties": {
                     "version": "1.0.3",
@@ -2367,22 +3399,27 @@
                     "dev": true
                 },
                 "uglify-js": {
-                    "version": "2.8.27",
+                    "version": "2.8.29",
                     "bundled": true,
                     "dev": true,
                     "optional": true,
+                    "requires": {
+                        "source-map": "0.5.6",
+                        "uglify-to-browserify": "1.0.2",
+                        "yargs": "3.10.0"
+                    },
                     "dependencies": {
-                        "camelcase": {
-                            "version": "1.2.1",
-                            "bundled": true,
-                            "dev": true,
-                            "optional": true
-                        },
                         "yargs": {
                             "version": "3.10.0",
                             "bundled": true,
                             "dev": true,
-                            "optional": true
+                            "optional": true,
+                            "requires": {
+                                "camelcase": "1.2.1",
+                                "cliui": "2.1.0",
+                                "decamelize": "1.2.0",
+                                "window-size": "0.1.0"
+                            }
                         }
                     }
                 },
@@ -2395,12 +3432,19 @@
                 "validate-npm-package-license": {
                     "version": "3.0.1",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "spdx-correct": "1.0.2",
+                        "spdx-expression-parse": "1.0.4"
+                    }
                 },
                 "which": {
                     "version": "1.2.14",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "isexe": "2.0.0"
+                    }
                 },
                 "which-module": {
                     "version": "2.0.0",
@@ -2422,11 +3466,20 @@
                     "version": "2.1.0",
                     "bundled": true,
                     "dev": true,
+                    "requires": {
+                        "string-width": "1.0.2",
+                        "strip-ansi": "3.0.1"
+                    },
                     "dependencies": {
                         "string-width": {
                             "version": "1.0.2",
                             "bundled": true,
-                            "dev": true
+                            "dev": true,
+                            "requires": {
+                                "code-point-at": "1.1.0",
+                                "is-fullwidth-code-point": "1.0.0",
+                                "strip-ansi": "3.0.1"
+                            }
                         }
                     }
                 },
@@ -2438,7 +3491,12 @@
                 "write-file-atomic": {
                     "version": "1.3.4",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "graceful-fs": "4.1.11",
+                        "imurmurhash": "0.1.4",
+                        "slide": "1.1.6"
+                    }
                 },
                 "y18n": {
                     "version": "3.2.1",
@@ -2451,9 +3509,24 @@
                     "dev": true
                 },
                 "yargs": {
-                    "version": "8.0.1",
+                    "version": "8.0.2",
                     "bundled": true,
                     "dev": true,
+                    "requires": {
+                        "camelcase": "4.1.0",
+                        "cliui": "3.2.0",
+                        "decamelize": "1.2.0",
+                        "get-caller-file": "1.0.2",
+                        "os-locale": "2.0.0",
+                        "read-pkg-up": "2.0.0",
+                        "require-directory": "2.1.1",
+                        "require-main-filename": "1.0.1",
+                        "set-blocking": "2.0.0",
+                        "string-width": "2.0.0",
+                        "which-module": "2.0.0",
+                        "y18n": "3.2.1",
+                        "yargs-parser": "7.0.0"
+                    },
                     "dependencies": {
                         "camelcase": {
                             "version": "4.1.0",
@@ -2464,33 +3537,61 @@
                             "version": "3.2.0",
                             "bundled": true,
                             "dev": true,
+                            "requires": {
+                                "string-width": "1.0.2",
+                                "strip-ansi": "3.0.1",
+                                "wrap-ansi": "2.1.0"
+                            },
                             "dependencies": {
                                 "string-width": {
                                     "version": "1.0.2",
                                     "bundled": true,
-                                    "dev": true
+                                    "dev": true,
+                                    "requires": {
+                                        "code-point-at": "1.1.0",
+                                        "is-fullwidth-code-point": "1.0.0",
+                                        "strip-ansi": "3.0.1"
+                                    }
                                 }
                             }
                         },
                         "load-json-file": {
                             "version": "2.0.0",
                             "bundled": true,
-                            "dev": true
+                            "dev": true,
+                            "requires": {
+                                "graceful-fs": "4.1.11",
+                                "parse-json": "2.2.0",
+                                "pify": "2.3.0",
+                                "strip-bom": "3.0.0"
+                            }
                         },
                         "path-type": {
                             "version": "2.0.0",
                             "bundled": true,
-                            "dev": true
+                            "dev": true,
+                            "requires": {
+                                "pify": "2.3.0"
+                            }
                         },
                         "read-pkg": {
                             "version": "2.0.0",
                             "bundled": true,
-                            "dev": true
+                            "dev": true,
+                            "requires": {
+                                "load-json-file": "2.0.0",
+                                "normalize-package-data": "2.3.8",
+                                "path-type": "2.0.0"
+                            }
                         },
                         "read-pkg-up": {
                             "version": "2.0.0",
                             "bundled": true,
-                            "dev": true
+                            "dev": true,
+                            "requires": {
+                                "find-up": "2.1.0",
+                                "read-pkg": "2.0.0"
+                            }
                         },
                         "strip-bom": {
                             "version": "3.0.0",
@@ -2500,7 +3601,10 @@
                         "yargs-parser": {
                             "version": "7.0.0",
                             "bundled": true,
-                            "dev": true
+                            "dev": true,
+                            "requires": {
+                                "camelcase": "4.1.0"
+                            }
                         }
                     }
                 },
@@ -2508,6 +3612,9 @@
                     "version": "5.0.0",
                     "bundled": true,
                     "dev": true,
+                    "requires": {
+                        "camelcase": "3.0.0"
+                    },
                     "dependencies": {
                         "camelcase": {
                             "version": "3.0.0",
@@ -2534,13 +3641,20 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
             "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "for-own": "0.1.5",
+                "is-extendable": "0.1.1"
+            }
         },
         "once": {
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
             "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "wrappy": "1.0.2"
+            }
         },
         "open": {
             "version": "0.0.5",
@@ -2551,13 +3665,23 @@
             "version": "0.3.0",
             "resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.3.0.tgz",
             "integrity": "sha1-cTfmmzKYuzQiR6G77jiByA4v14s=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "is-stream": "1.1.0",
+                "readable-stream": "2.3.3"
+            }
         },
         "parse-glob": {
             "version": "3.0.4",
             "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
             "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
             "dev": true,
+            "requires": {
+                "glob-base": "0.3.0",
+                "is-dotfile": "1.0.3",
+                "is-extglob": "1.0.0",
+                "is-glob": "2.0.1"
+            },
             "dependencies": {
                 "is-extglob": {
                     "version": "1.0.0",
@@ -2569,7 +3693,10 @@
                     "version": "2.0.1",
                     "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
                     "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "is-extglob": "1.0.0"
+                    }
                 }
             }
         },
@@ -2595,7 +3722,10 @@
             "version": "1.7.0",
             "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
             "integrity": "sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "isarray": "0.0.1"
+            }
         },
         "pathval": {
             "version": "1.1.0",
@@ -2607,7 +3737,10 @@
             "version": "0.0.11",
             "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
             "integrity": "sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "through": "2.3.8"
+            }
         },
         "pend": {
             "version": "1.2.0",
@@ -2631,7 +3764,10 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
             "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "pinkie": "2.0.4"
+            }
         },
         "preserve": {
             "version": "0.2.0",
@@ -2657,29 +3793,48 @@
             "integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM=",
             "dev": true
         },
+        "querystringify": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-1.0.0.tgz",
+            "integrity": "sha1-YoYkIRLFtxL6ZU5SZlK/ahP/Bcs=",
+            "dev": true
+        },
         "queue": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/queue/-/queue-3.1.0.tgz",
             "integrity": "sha1-bEnQHwCeIlZ4h4nyv/rGuLmZBYU=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "inherits": "2.0.3"
+            }
         },
         "randomatic": {
             "version": "1.1.7",
             "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
             "integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
             "dev": true,
+            "requires": {
+                "is-number": "3.0.0",
+                "kind-of": "4.0.0"
+            },
             "dependencies": {
                 "is-number": {
                     "version": "3.0.0",
                     "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
                     "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
                     "dev": true,
+                    "requires": {
+                        "kind-of": "3.2.2"
+                    },
                     "dependencies": {
                         "kind-of": {
                             "version": "3.2.2",
                             "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                             "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-                            "dev": true
+                            "dev": true,
+                            "requires": {
+                                "is-buffer": "1.1.5"
+                            }
                         }
                     }
                 },
@@ -2687,26 +3842,32 @@
                     "version": "4.0.0",
                     "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
                     "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "is-buffer": "1.1.5"
+                    }
                 }
             }
         },
         "readable-stream": {
-            "version": "2.2.11",
-            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.11.tgz",
-            "integrity": "sha512-h+8+r3MKEhkiVrwdKL8aWs1oc1VvBu33ueshOvS26RsZQ3Amhx/oO3TKe4lApSV9ueY6as8EAh7mtuFjdlhg9Q==",
+            "version": "2.3.3",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
+            "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
             "dev": true,
+            "requires": {
+                "core-util-is": "1.0.2",
+                "inherits": "2.0.3",
+                "isarray": "1.0.0",
+                "process-nextick-args": "1.0.7",
+                "safe-buffer": "5.1.1",
+                "string_decoder": "1.0.3",
+                "util-deprecate": "1.0.2"
+            },
             "dependencies": {
                 "isarray": {
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
                     "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-                    "dev": true
-                },
-                "safe-buffer": {
-                    "version": "5.0.1",
-                    "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz",
-                    "integrity": "sha1-0mPKVGls2KMGtcplUekt5XkY++c=",
                     "dev": true
                 }
             }
@@ -2715,13 +3876,20 @@
             "version": "0.6.2",
             "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
             "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "resolve": "1.3.3"
+            }
         },
         "regex-cache": {
             "version": "0.4.3",
             "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.3.tgz",
             "integrity": "sha1-mxpsNdTQ3871cRrmUejp09cRQUU=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "is-equal-shallow": "0.1.3",
+                "is-primitive": "2.0.0"
+            }
         },
         "remove-trailing-separator": {
             "version": "1.0.2",
@@ -2751,24 +3919,60 @@
             "version": "2.81.0",
             "resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
             "integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
+            "dev": true,
+            "requires": {
+                "aws-sign2": "0.6.0",
+                "aws4": "1.6.0",
+                "caseless": "0.12.0",
+                "combined-stream": "1.0.5",
+                "extend": "3.0.1",
+                "forever-agent": "0.6.1",
+                "form-data": "2.1.4",
+                "har-validator": "4.2.1",
+                "hawk": "3.1.3",
+                "http-signature": "1.1.1",
+                "is-typedarray": "1.0.0",
+                "isstream": "0.1.2",
+                "json-stringify-safe": "5.0.1",
+                "mime-types": "2.1.15",
+                "oauth-sign": "0.8.2",
+                "performance-now": "0.2.0",
+                "qs": "6.4.0",
+                "safe-buffer": "5.1.1",
+                "stringstream": "0.0.5",
+                "tough-cookie": "2.3.2",
+                "tunnel-agent": "0.6.0",
+                "uuid": "3.1.0"
+            }
+        },
+        "requires-port": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+            "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=",
             "dev": true
         },
         "resolve": {
             "version": "1.3.3",
             "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.3.3.tgz",
             "integrity": "sha1-ZVkHw0aahoDcLeOidaj91paR8OU=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "path-parse": "1.0.5"
+            }
         },
         "rimraf": {
             "version": "2.6.1",
             "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
             "integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "glob": "7.1.2"
+            }
         },
         "safe-buffer": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.0.tgz",
-            "integrity": "sha512-aSLEDudu6OoRr/2rU609gRmnYboRLxgDG1z9o2Q0os7236FwvcqIOO8r8U5JUEwivZOhDaKlFO4SbPTJYyBEyQ==",
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+            "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
             "dev": true
         },
         "samsam": {
@@ -2786,19 +3990,37 @@
             "version": "0.7.7",
             "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.7.7.tgz",
             "integrity": "sha1-svXHfvlxSPS09uImguELuoZnz/E=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "glob": "7.1.2",
+                "interpret": "1.0.3",
+                "rechoir": "0.6.2"
+            }
         },
         "sinon": {
-            "version": "2.3.4",
-            "resolved": "https://registry.npmjs.org/sinon/-/sinon-2.3.4.tgz",
-            "integrity": "sha1-RmrY0brobW21GqIYuS6Ze8Pl24g=",
-            "dev": true
+            "version": "2.3.6",
+            "resolved": "https://registry.npmjs.org/sinon/-/sinon-2.3.6.tgz",
+            "integrity": "sha1-lTeOfg+XapcS6bRZH/WznnPcPd4=",
+            "dev": true,
+            "requires": {
+                "diff": "3.2.0",
+                "formatio": "1.2.0",
+                "lolex": "1.6.0",
+                "native-promise-only": "0.8.1",
+                "path-to-regexp": "1.7.0",
+                "samsam": "1.2.1",
+                "text-encoding": "0.6.4",
+                "type-detect": "4.0.3"
+            }
         },
         "sntp": {
             "version": "1.0.9",
             "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
             "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "hoek": "2.16.3"
+            }
         },
         "source-map": {
             "version": "0.5.6",
@@ -2810,7 +4032,10 @@
             "version": "0.4.15",
             "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.15.tgz",
             "integrity": "sha1-AyAt9lwG0r2MfsI2KhkwVv7407E=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "source-map": "0.5.6"
+            }
         },
         "sparkles": {
             "version": "1.0.0",
@@ -2822,13 +4047,26 @@
             "version": "0.3.3",
             "resolved": "https://registry.npmjs.org/split/-/split-0.3.3.tgz",
             "integrity": "sha1-zQ7qXmOiEd//frDwkcQTPi0N0o8=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "through": "2.3.8"
+            }
         },
         "sshpk": {
             "version": "1.13.1",
             "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
             "integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
             "dev": true,
+            "requires": {
+                "asn1": "0.2.3",
+                "assert-plus": "1.0.0",
+                "bcrypt-pbkdf": "1.0.1",
+                "dashdash": "1.14.1",
+                "ecc-jsbn": "0.1.1",
+                "getpass": "0.1.7",
+                "jsbn": "0.1.1",
+                "tweetnacl": "0.14.5"
+            },
             "dependencies": {
                 "assert-plus": {
                     "version": "1.0.0",
@@ -2848,7 +4086,10 @@
             "version": "0.0.4",
             "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz",
             "integrity": "sha1-TV5DPBhSYd3mI8o/RMWGvPXErRQ=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "duplexer": "0.1.1"
+            }
         },
         "stream-shift": {
             "version": "1.0.0",
@@ -2860,7 +4101,10 @@
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/streamfilter/-/streamfilter-1.0.5.tgz",
             "integrity": "sha1-h1BxEb644phFFxe1Ec/tjwAqv1M=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "readable-stream": "2.3.3"
+            }
         },
         "streamifier": {
             "version": "0.1.1",
@@ -2869,17 +4113,12 @@
             "dev": true
         },
         "string_decoder": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.2.tgz",
-            "integrity": "sha1-sp4fThEl+pehA4K4pTNze3SR4Xk=",
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+            "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
             "dev": true,
-            "dependencies": {
-                "safe-buffer": {
-                    "version": "5.0.1",
-                    "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz",
-                    "integrity": "sha1-0mPKVGls2KMGtcplUekt5XkY++c=",
-                    "dev": true
-                }
+            "requires": {
+                "safe-buffer": "5.1.1"
             }
         },
         "stringstream": {
@@ -2892,19 +4131,29 @@
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
             "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "ansi-regex": "2.1.1"
+            }
         },
         "strip-bom": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
             "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "is-utf8": "0.2.1"
+            }
         },
         "strip-bom-stream": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/strip-bom-stream/-/strip-bom-stream-1.0.0.tgz",
             "integrity": "sha1-5xRDmFd9Uaa+0PoZlPoF9D/ZiO4=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "first-chunk-stream": "1.0.0",
+                "strip-bom": "2.0.0"
+            }
         },
         "supports-color": {
             "version": "2.0.0",
@@ -2916,7 +4165,12 @@
             "version": "2.2.1",
             "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
             "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "block-stream": "0.0.9",
+                "fstream": "1.0.11",
+                "inherits": "2.0.3"
+            }
         },
         "text-encoding": {
             "version": "0.6.4",
@@ -2934,13 +4188,21 @@
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
             "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "readable-stream": "2.3.3",
+                "xtend": "4.0.1"
+            }
         },
         "through2-filter": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/through2-filter/-/through2-filter-2.0.0.tgz",
             "integrity": "sha1-YLxVoNrLdghdsfna6Zq0P4PWIuw=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "through2": "2.0.3",
+                "xtend": "4.0.1"
+            }
         },
         "time-stamp": {
             "version": "1.1.0",
@@ -2952,13 +4214,19 @@
             "version": "0.1.1",
             "resolved": "https://registry.npmjs.org/to-absolute-glob/-/to-absolute-glob-0.1.1.tgz",
             "integrity": "sha1-HN+kcqnvUMI57maZm2YsoOs5k38=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "extend-shallow": "2.0.1"
+            }
         },
         "tough-cookie": {
             "version": "2.3.2",
             "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
             "integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "punycode": "1.4.1"
+            }
         },
         "tslib": {
             "version": "1.7.1",
@@ -2967,22 +4235,40 @@
             "dev": true
         },
         "tslint": {
-            "version": "5.4.3",
-            "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.4.3.tgz",
-            "integrity": "sha1-dhyEArgONHt3M6BDkKdXslNYBGc=",
-            "dev": true
+            "version": "5.5.0",
+            "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.5.0.tgz",
+            "integrity": "sha1-EOjas+MGH6YelELozuOYKs8gpqo=",
+            "dev": true,
+            "requires": {
+                "babel-code-frame": "6.22.0",
+                "colors": "1.1.2",
+                "commander": "2.11.0",
+                "diff": "3.2.0",
+                "glob": "7.1.2",
+                "minimatch": "3.0.4",
+                "resolve": "1.3.3",
+                "semver": "5.3.0",
+                "tslib": "1.7.1",
+                "tsutils": "2.5.1"
+            }
         },
         "tsutils": {
-            "version": "2.4.0",
-            "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.4.0.tgz",
-            "integrity": "sha1-rUzm26Dlo+2934Ymt8oEB4IYn+o=",
-            "dev": true
+            "version": "2.5.1",
+            "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.5.1.tgz",
+            "integrity": "sha1-wgATkMee7Bpcz6esEtWZY5aD4M8=",
+            "dev": true,
+            "requires": {
+                "tslib": "1.7.1"
+            }
         },
         "tunnel-agent": {
             "version": "0.6.0",
             "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
             "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "safe-buffer": "5.1.1"
+            }
         },
         "tweetnacl": {
             "version": "0.14.5",
@@ -2998,16 +4284,30 @@
             "dev": true
         },
         "typescript": {
-            "version": "2.3.4",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.3.4.tgz",
-            "integrity": "sha1-PTgyGCgjHkNPKHUUlZw3qCtin0I=",
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.4.1.tgz",
+            "integrity": "sha1-w8yxbdqgsjFN4DHn5v7onlujRrw=",
             "dev": true
         },
         "unique-stream": {
             "version": "2.2.1",
             "resolved": "https://registry.npmjs.org/unique-stream/-/unique-stream-2.2.1.tgz",
             "integrity": "sha1-WqADz76Uxf+GbE59ZouxxNuts2k=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "json-stable-stringify": "1.0.1",
+                "through2-filter": "2.0.0"
+            }
+        },
+        "url-parse": {
+            "version": "1.1.9",
+            "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.1.9.tgz",
+            "integrity": "sha1-xn8dd11R8KGJEd17P/rSe7nlvRk=",
+            "dev": true,
+            "requires": {
+                "querystringify": "1.0.0",
+                "requires-port": "1.0.0"
+            }
         },
         "urlgrey": {
             "version": "0.4.4",
@@ -3037,19 +4337,46 @@
             "version": "1.3.6",
             "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
             "integrity": "sha1-z/XfEpRtKX0rqu+qJoniW+AcAFw=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "extsprintf": "1.0.2"
+            }
         },
         "vinyl": {
             "version": "0.5.3",
             "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.5.3.tgz",
             "integrity": "sha1-sEVbOPxeDPMNQyUTLkYZcMIJHN4=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "clone": "1.0.2",
+                "clone-stats": "0.0.1",
+                "replace-ext": "0.0.1"
+            }
         },
         "vinyl-fs": {
             "version": "2.4.4",
             "resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-2.4.4.tgz",
             "integrity": "sha1-vm/zJwy1Xf19MGNkDegfJddTIjk=",
             "dev": true,
+            "requires": {
+                "duplexify": "3.5.0",
+                "glob-stream": "5.3.5",
+                "graceful-fs": "4.1.11",
+                "gulp-sourcemaps": "1.6.0",
+                "is-valid-glob": "0.3.0",
+                "lazystream": "1.0.0",
+                "lodash.isequal": "4.5.0",
+                "merge-stream": "1.0.1",
+                "mkdirp": "0.5.1",
+                "object-assign": "4.1.1",
+                "readable-stream": "2.3.3",
+                "strip-bom": "2.0.0",
+                "strip-bom-stream": "1.0.0",
+                "through2": "2.0.3",
+                "through2-filter": "2.0.0",
+                "vali-date": "1.0.0",
+                "vinyl": "1.2.0"
+            },
             "dependencies": {
                 "object-assign": {
                     "version": "4.1.1",
@@ -3061,7 +4388,12 @@
                     "version": "1.2.0",
                     "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
                     "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "clone": "1.0.2",
+                        "clone-stats": "0.0.1",
+                        "replace-ext": "0.0.1"
+                    }
                 }
             }
         },
@@ -3070,6 +4402,10 @@
             "resolved": "https://registry.npmjs.org/vinyl-source-stream/-/vinyl-source-stream-1.1.0.tgz",
             "integrity": "sha1-RMvlEIIFJ53rDFZTwJSiiHk4sas=",
             "dev": true,
+            "requires": {
+                "through2": "0.6.5",
+                "vinyl": "0.4.6"
+            },
             "dependencies": {
                 "clone": {
                     "version": "0.2.0",
@@ -3081,7 +4417,13 @@
                     "version": "1.0.34",
                     "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
                     "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "core-util-is": "1.0.2",
+                        "inherits": "2.0.3",
+                        "isarray": "0.0.1",
+                        "string_decoder": "0.10.31"
+                    }
                 },
                 "string_decoder": {
                     "version": "0.10.31",
@@ -3093,21 +4435,45 @@
                     "version": "0.6.5",
                     "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
                     "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "readable-stream": "1.0.34",
+                        "xtend": "4.0.1"
+                    }
                 },
                 "vinyl": {
                     "version": "0.4.6",
                     "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
                     "integrity": "sha1-LzVsh6VQolVGHza76ypbqL94SEc=",
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "clone": "0.2.0",
+                        "clone-stats": "0.0.1"
+                    }
                 }
             }
         },
         "vscode": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/vscode/-/vscode-1.1.0.tgz",
-            "integrity": "sha1-sEwjmbbsdoE1yWiOeHPXduKNy5U=",
-            "dev": true
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/vscode/-/vscode-1.1.2.tgz",
+            "integrity": "sha1-GKKedChTzVPzwUd67CinKJVyHck=",
+            "dev": true,
+            "requires": {
+                "glob": "7.1.2",
+                "gulp-chmod": "2.0.0",
+                "gulp-filter": "5.0.0",
+                "gulp-gunzip": "0.0.3",
+                "gulp-remote-src": "0.4.2",
+                "gulp-symdest": "1.1.0",
+                "gulp-untar": "0.0.6",
+                "gulp-vinyl-zip": "1.4.0",
+                "mocha": "3.4.2",
+                "request": "2.81.0",
+                "semver": "5.3.0",
+                "source-map-support": "0.4.15",
+                "url-parse": "1.1.9",
+                "vinyl-source-stream": "1.1.0"
+            }
         },
         "wrappy": {
             "version": "1.0.2",
@@ -3125,13 +4491,20 @@
             "version": "2.8.0",
             "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.8.0.tgz",
             "integrity": "sha1-eUUK/yKyqcWkHvVOAtuQfM+/nuI=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "buffer-crc32": "0.2.13",
+                "fd-slicer": "1.0.1"
+            }
         },
         "yazl": {
             "version": "2.4.2",
             "resolved": "https://registry.npmjs.org/yazl/-/yazl-2.4.2.tgz",
             "integrity": "sha1-FMsZCD4eJacAksFYiqvg9OTdTYg=",
-            "dev": true
+            "dev": true,
+            "requires": {
+                "buffer-crc32": "0.2.13"
+            }
         }
     }
 }

--- a/package.json
+++ b/package.json
@@ -211,23 +211,23 @@
         "analysis": "bithound check git@github.com:vscode-icons/vscode-icons.git"
     },
     "devDependencies": {
-        "@types/chai": "^4.0.0",
-        "@types/lodash": "^4.14.66",
+        "@types/chai": "^4.0.1",
+        "@types/lodash": "^4.14.68",
         "@types/mocha": "^2.2.41",
         "@types/mockery": "^1.4.29",
-        "@types/node": "^7.0.31",
-        "@types/sinon": "^2.3.1",
+        "@types/node": "^7.0.33",
+        "@types/sinon": "^2.3.2",
         "bithound": "^1.7.0",
         "chai": "^4.0.2",
         "codecov": "^2.2.0",
         "mocha": "^3.4.2",
-        "mockery": "^2.0.0",
-        "nyc": "^11.0.2",
+        "mockery": "^2.1.0",
+        "nyc": "^11.0.3",
         "rimraf": "^2.6.1",
-        "sinon": "^2.3.4",
-        "tslint": "^5.4.3",
-        "typescript": "^2.3.4",
-        "vscode": "^1.1.0"
+        "sinon": "^2.3.6",
+        "tslint": "^5.5.0",
+        "typescript": "^2.4.1",
+        "vscode": "^1.1.2"
     },
     "dependencies": {
         "lodash": "^4.17.4",

--- a/src/index.ts
+++ b/src/index.ts
@@ -40,14 +40,14 @@ function detectAngular(config: IVSIcons, results: IVSCodeUri[]): void {
 
   const i18nManager = new LanguageResourceManager(vscode.env.language);
   const presetValue = getConfig().inspect(`vsicons.presets.angular`).workspaceValue as boolean;
-  const result = init.checkForAngularProject(
+  const detectionResult = init.checkForAngularProject(
     presetValue, init.iconsDisabled('ng'), isNgProject, i18nManager);
 
-  if (!result.apply) {
+  if (!detectionResult.apply) {
     return;
   }
 
-  init.applyDetection(i18nManager, result, config.projectDetection.autoReload,
+  init.applyDetection(i18nManager, detectionResult, config.projectDetection.autoReload,
     commands.applyCustomization, commands.showCustomizationMessage, commands.reload);
 }
 

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -36,19 +36,19 @@ export function fileFormatToString(extension: FileFormat | string): string {
 /**
  * Deletes a directory and all subdirectories
  *
- * @param {any} path The directory's path
+ * @param {any} dirPath The directory's path
  */
-export function deleteDirectoryRecursively(path): void {
-  if (fs.existsSync(path)) {
-    fs.readdirSync(path).forEach(file => {
-      const curPath = `${path}/${file}`;
+export function deleteDirectoryRecursively(dirPath: string): void {
+  if (fs.existsSync(dirPath)) {
+    fs.readdirSync(dirPath).forEach(file => {
+      const curPath = `${dirPath}/${file}`;
       if (fs.lstatSync(curPath).isDirectory()) { // recurse
         deleteDirectoryRecursively(curPath);
       } else { // delete file
         fs.unlinkSync(curPath);
       }
     });
-    fs.rmdirSync(path);
+    fs.rmdirSync(dirPath);
   }
 }
 
@@ -110,11 +110,11 @@ export function flatten(obj: object, separator = '.'): object {
     const hasKeys = !!Object.keys(value).length;
     return !isArray && !isBuffer && isΟbject && hasKeys;
   };
-  const _flatten = (child: any, path = []): object[] => {
+  const _flatten = (child: any, paths = []): object[] => {
     return [].concat(...Object.keys(child)
       .map(key => isValidObject(child[key])
-        ? _flatten(child[key], [...path, key])
-        : { [[...path, key].join(separator)]: child[key] }));
+        ? _flatten(child[key], [...paths, key])
+        : { [[...paths, key].join(separator)]: child[key] }));
   };
   return Object.assign({}, ..._flatten(obj));
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,13 +2,13 @@
 # yarn lockfile v1
 
 
-"@types/chai@^4.0.0":
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/@types/chai/-/chai-4.0.0.tgz#4c9adabd2d04265769e6d9e847e86cc404dc7dcd"
+"@types/chai@^4.0.1":
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/@types/chai/-/chai-4.0.1.tgz#37fea779617cfec3fd2b19a0247e8bbdd5133bf6"
 
-"@types/lodash@^4.14.66":
-  version "4.14.66"
-  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.66.tgz#3dbb83477becf130611f8fac82a8fdb199805981"
+"@types/lodash@^4.14.68":
+  version "4.14.68"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.68.tgz#754fbab68bd2bbb69547dc8ce7574f7012eed7f6"
 
 "@types/mocha@^2.2.41":
   version "2.2.41"
@@ -18,13 +18,13 @@
   version "1.4.29"
   resolved "https://registry.yarnpkg.com/@types/mockery/-/mockery-1.4.29.tgz#9ba22df37f07e3780fff8531d1a38e633f9457a5"
 
-"@types/node@^7.0.31":
-  version "7.0.31"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-7.0.31.tgz#80ea4d175599b2a00149c29a10a4eb2dff592e86"
+"@types/node@^7.0.33":
+  version "7.0.33"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-7.0.33.tgz#ae3c53ad01d7e9d62c7f1a85c5f7500d59b9d25b"
 
-"@types/sinon@^2.3.1":
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/@types/sinon/-/sinon-2.3.1.tgz#5e214093e9e2345219ab0f31bf310c9790ad0712"
+"@types/sinon@^2.3.2":
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/@types/sinon/-/sinon-2.3.2.tgz#1e1e99e67162d78e2db17816892bf93bf5209885"
 
 ajv@^4.9.1:
   version "4.11.8"
@@ -48,6 +48,10 @@ amdefine@>=0.0.4:
 ansi-regex@^2.0.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-2.1.1.tgz#c3b33ab5ee360d86e0e628f0468ae7ef27d654df"
+
+ansi-regex@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-3.0.0.tgz#ed0317c322064f79466c02966bddb605ab37d998"
 
 ansi-styles@^2.2.1:
   version "2.2.1"
@@ -74,8 +78,8 @@ arr-diff@^2.0.0:
     arr-flatten "^1.0.1"
 
 arr-flatten@^1.0.1:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/arr-flatten/-/arr-flatten-1.0.3.tgz#a274ed85ac08849b6bd7847c4580745dc51adfb1"
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/arr-flatten/-/arr-flatten-1.1.0.tgz#36048bbff4e7b47e136644316c99669ea5ae91f1"
 
 array-differ@^1.0.0:
   version "1.0.0"
@@ -120,8 +124,8 @@ async@^1.4.0:
   resolved "https://registry.yarnpkg.com/async/-/async-1.5.2.tgz#ec6a61ae56480c0c3cb241c95618e20892f9672a"
 
 async@^2.0.0:
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/async/-/async-2.4.0.tgz#4990200f18ea5b837c2cc4f8c031a6985c385611"
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/async/-/async-2.5.0.tgz#843190fd6b7357a0b9e1c956edddd5ec8462b54d"
   dependencies:
     lodash "^4.14.0"
 
@@ -146,12 +150,12 @@ babel-code-frame@^6.22.0:
     js-tokens "^3.0.0"
 
 babel-generator@^6.18.0:
-  version "6.24.1"
-  resolved "https://registry.yarnpkg.com/babel-generator/-/babel-generator-6.24.1.tgz#e715f486c58ded25649d888944d52aa07c5d9497"
+  version "6.25.0"
+  resolved "https://registry.yarnpkg.com/babel-generator/-/babel-generator-6.25.0.tgz#33a1af70d5f2890aeb465a4a7793c1df6a9ea9fc"
   dependencies:
     babel-messages "^6.23.0"
     babel-runtime "^6.22.0"
-    babel-types "^6.24.1"
+    babel-types "^6.25.0"
     detect-indent "^4.0.0"
     jsesc "^1.3.0"
     lodash "^4.2.0"
@@ -172,45 +176,45 @@ babel-runtime@^6.22.0:
     regenerator-runtime "^0.10.0"
 
 babel-template@^6.16.0:
-  version "6.24.1"
-  resolved "https://registry.yarnpkg.com/babel-template/-/babel-template-6.24.1.tgz#04ae514f1f93b3a2537f2a0f60a5a45fb8308333"
+  version "6.25.0"
+  resolved "https://registry.yarnpkg.com/babel-template/-/babel-template-6.25.0.tgz#665241166b7c2aa4c619d71e192969552b10c071"
   dependencies:
     babel-runtime "^6.22.0"
-    babel-traverse "^6.24.1"
-    babel-types "^6.24.1"
-    babylon "^6.11.0"
+    babel-traverse "^6.25.0"
+    babel-types "^6.25.0"
+    babylon "^6.17.2"
     lodash "^4.2.0"
 
-babel-traverse@^6.18.0, babel-traverse@^6.24.1:
-  version "6.24.1"
-  resolved "https://registry.yarnpkg.com/babel-traverse/-/babel-traverse-6.24.1.tgz#ab36673fd356f9a0948659e7b338d5feadb31695"
+babel-traverse@^6.18.0, babel-traverse@^6.25.0:
+  version "6.25.0"
+  resolved "https://registry.yarnpkg.com/babel-traverse/-/babel-traverse-6.25.0.tgz#2257497e2fcd19b89edc13c4c91381f9512496f1"
   dependencies:
     babel-code-frame "^6.22.0"
     babel-messages "^6.23.0"
     babel-runtime "^6.22.0"
-    babel-types "^6.24.1"
-    babylon "^6.15.0"
+    babel-types "^6.25.0"
+    babylon "^6.17.2"
     debug "^2.2.0"
     globals "^9.0.0"
     invariant "^2.2.0"
     lodash "^4.2.0"
 
-babel-types@^6.18.0, babel-types@^6.24.1:
-  version "6.24.1"
-  resolved "https://registry.yarnpkg.com/babel-types/-/babel-types-6.24.1.tgz#a136879dc15b3606bda0d90c1fc74304c2ff0975"
+babel-types@^6.18.0, babel-types@^6.25.0:
+  version "6.25.0"
+  resolved "https://registry.yarnpkg.com/babel-types/-/babel-types-6.25.0.tgz#70afb248d5660e5d18f811d91c8303b54134a18e"
   dependencies:
     babel-runtime "^6.22.0"
     esutils "^2.0.2"
     lodash "^4.2.0"
     to-fast-properties "^1.0.1"
 
-babylon@^6.11.0, babylon@^6.13.0, babylon@^6.15.0:
-  version "6.17.1"
-  resolved "https://registry.yarnpkg.com/babylon/-/babylon-6.17.1.tgz#17f14fddf361b695981fe679385e4f1c01ebd86f"
+babylon@^6.17.2, babylon@^6.17.4:
+  version "6.17.4"
+  resolved "https://registry.yarnpkg.com/babylon/-/babylon-6.17.4.tgz#3e8b7402b88d22c3423e137a1577883b15ff869a"
 
-balanced-match@^0.4.1:
-  version "0.4.2"
-  resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-0.4.2.tgz#cb3f3e3c732dc0f01ee70b403f302e61d7709838"
+balanced-match@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
 
 bcrypt-pbkdf@^1.0.0:
   version "1.0.1"
@@ -246,10 +250,10 @@ boom@2.x.x:
     hoek "2.x.x"
 
 brace-expansion@^1.1.7:
-  version "1.1.7"
-  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.7.tgz#3effc3c50e000531fb720eaff80f0ae8ef23cf59"
+  version "1.1.8"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.8.tgz#c07b211c7c952ec1f8efd51a77ef0d1d3990a292"
   dependencies:
-    balanced-match "^0.4.1"
+    balanced-match "^1.0.0"
     concat-map "0.0.1"
 
 braces@^1.8.2:
@@ -267,10 +271,6 @@ browser-stdout@1.3.0:
 buffer-crc32@~0.2.3:
   version "0.2.13"
   resolved "https://registry.yarnpkg.com/buffer-crc32/-/buffer-crc32-0.2.13.tgz#0d333e3f00eac50aa1454abd30ef8c2a5d9a7242"
-
-buffer-shims@~1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/buffer-shims/-/buffer-shims-1.0.0.tgz#9978ce317388c649ad8793028c3477ef044a8b51"
 
 builtin-modules@^1.0.0:
   version "1.1.1"
@@ -406,11 +406,15 @@ combined-stream@^1.0.5, combined-stream@~1.0.5:
   dependencies:
     delayed-stream "~1.0.0"
 
-commander@2.9.0, commander@^2.8.1, commander@^2.9.0:
+commander@2.9.0:
   version "2.9.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.9.0.tgz#9c99094176e12240cb22d6c5146098400fe0f7d4"
   dependencies:
     graceful-readlink ">= 1.0.0"
+
+commander@^2.8.1, commander@^2.9.0:
+  version "2.11.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.11.0.tgz#157152fd1e7a6c8d98a5b715cf376df928004563"
 
 commondir@^1.0.1:
   version "1.0.1"
@@ -466,10 +470,10 @@ debug@2.6.0:
     ms "0.7.2"
 
 debug@^2.2.0, debug@^2.6.3:
-  version "2.6.6"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.6.tgz#a9fa6fbe9ca43cf1e79f73b75c0189cbb7d6db5a"
+  version "2.6.8"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.8.tgz#e731531ca2ede27d188222427da17821d68ff4fc"
   dependencies:
-    ms "0.7.3"
+    ms "2.0.0"
 
 decamelize@^1.0.0, decamelize@^1.1.1:
   version "1.2.0"
@@ -810,8 +814,8 @@ glob@^5.0.3:
     path-is-absolute "^1.0.0"
 
 globals@^9.0.0:
-  version "9.17.0"
-  resolved "https://registry.yarnpkg.com/globals/-/globals-9.17.0.tgz#0c0ca696d9b9bb694d2e5470bd37777caad50286"
+  version "9.18.0"
+  resolved "https://registry.yarnpkg.com/globals/-/globals-9.18.0.tgz#aa3896b3e69b487f17e31ed2143d69a8e30c2d8a"
 
 glogg@^1.0.0:
   version "1.0.0"
@@ -935,8 +939,8 @@ gulplog@^1.0.0:
     glogg "^1.0.0"
 
 handlebars@^4.0.3:
-  version "4.0.8"
-  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.0.8.tgz#22b875cd3f0e6cbea30314f144e82bc7a72ff420"
+  version "4.0.10"
+  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.0.10.tgz#3d30c718b09a3d96f23ea4cc1f403c4d3ba9ff4f"
   dependencies:
     async "^1.4.0"
     optimist "^0.6.1"
@@ -994,8 +998,8 @@ hoek@2.x.x:
   resolved "https://registry.yarnpkg.com/hoek/-/hoek-2.16.3.tgz#20bb7403d3cea398e91dc4710a8ff1b8274a25ed"
 
 hosted-git-info@^2.1.4:
-  version "2.4.2"
-  resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.4.2.tgz#0076b9f46a270506ddbaaea56496897460612a67"
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.5.0.tgz#6d60e34b3abbc8313062c3b798ef8d901a07af3c"
 
 http-signature@~1.1.0:
   version "1.1.1"
@@ -1016,7 +1020,7 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2, inherits@^2.0.1, inherits@~2.0.0, inherits@~2.0.1:
+inherits@2, inherits@^2.0.1, inherits@~2.0.0, inherits@~2.0.1, inherits@~2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
 
@@ -1049,8 +1053,8 @@ is-builtin-module@^1.0.0:
     builtin-modules "^1.0.0"
 
 is-dotfile@^1.0.0:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/is-dotfile/-/is-dotfile-1.0.2.tgz#2c132383f39199f8edc268ca01b9b007d205cc4d"
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/is-dotfile/-/is-dotfile-1.0.3.tgz#a6a2f32ffd2dfb04f5ca25ecd0f6b83cf798a1e1"
 
 is-equal-shallow@^0.1.3:
   version "0.1.3"
@@ -1107,9 +1111,15 @@ is-my-json-valid@^2.12.4:
     jsonpointer "^4.0.0"
     xtend "^4.0.0"
 
-is-number@^2.0.2, is-number@^2.1.0:
+is-number@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/is-number/-/is-number-2.1.0.tgz#01fcbbb393463a548f2f466cce16dece49db908f"
+  dependencies:
+    kind-of "^3.0.2"
+
+is-number@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/is-number/-/is-number-3.0.0.tgz#24fd6201a4782cf50561c810276afc7d12d71195"
   dependencies:
     kind-of "^3.0.2"
 
@@ -1181,15 +1191,15 @@ istanbul-lib-hook@^1.0.7:
   dependencies:
     append-transform "^0.4.0"
 
-istanbul-lib-instrument@^1.7.2:
-  version "1.7.2"
-  resolved "https://registry.yarnpkg.com/istanbul-lib-instrument/-/istanbul-lib-instrument-1.7.2.tgz#6014b03d3470fb77638d5802508c255c06312e56"
+istanbul-lib-instrument@^1.7.3:
+  version "1.7.3"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-instrument/-/istanbul-lib-instrument-1.7.3.tgz#925b239163eabdd68cc4048f52c2fa4f899ecfa7"
   dependencies:
     babel-generator "^6.18.0"
     babel-template "^6.16.0"
     babel-traverse "^6.18.0"
     babel-types "^6.18.0"
-    babylon "^6.13.0"
+    babylon "^6.17.4"
     istanbul-lib-coverage "^1.1.1"
     semver "^5.3.0"
 
@@ -1218,15 +1228,9 @@ istanbul-reports@^1.1.1:
   dependencies:
     handlebars "^4.0.3"
 
-jodid25519@^1.0.0:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/jodid25519/-/jodid25519-1.0.2.tgz#06d4912255093419477d425633606e0e90782967"
-  dependencies:
-    jsbn "~0.1.0"
-
 js-tokens@^3.0.0:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.1.tgz#08e9f132484a2c45a30907e9dc4d5567b7f114d7"
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
 
 jsbn@~0.1.0:
   version "0.1.1"
@@ -1272,8 +1276,14 @@ jsprim@^1.2.2:
     verror "1.3.6"
 
 kind-of@^3.0.2:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-3.2.0.tgz#b58abe4d5c044ad33726a8c1525b48cf891bff07"
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-3.2.2.tgz#31ea21a734bab9bbb0f32466d893aea51e4a3c64"
+  dependencies:
+    is-buffer "^1.1.5"
+
+kind-of@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-4.0.0.tgz#20813df3d712928b207378691a45066fae72dd57"
   dependencies:
     is-buffer "^1.1.5"
 
@@ -1444,11 +1454,11 @@ loose-envify@^1.0.0:
     js-tokens "^3.0.0"
 
 lru-cache@^4.0.1:
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-4.0.2.tgz#1d17679c069cda5d040991a09dbc2c0db377e55e"
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-4.1.1.tgz#622e32e82488b49279114a4f9ecf45e7cd6bba55"
   dependencies:
-    pseudomap "^1.0.1"
-    yallist "^2.0.0"
+    pseudomap "^1.0.2"
+    yallist "^2.1.2"
 
 map-stream@~0.1.0:
   version "0.1.0"
@@ -1471,10 +1481,10 @@ mem@^1.1.0:
     mimic-fn "^1.0.0"
 
 merge-source-map@^1.0.2:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/merge-source-map/-/merge-source-map-1.0.3.tgz#da1415f2722a5119db07b14c4f973410863a2abf"
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/merge-source-map/-/merge-source-map-1.0.4.tgz#a5de46538dae84d4114cc5ea02b4772a6346701f"
   dependencies:
-    source-map "^0.5.3"
+    source-map "^0.5.6"
 
 merge-stream@^1.0.0:
   version "1.0.1"
@@ -1550,17 +1560,17 @@ mocha@^3.2.0, mocha@^3.4.2:
     mkdirp "0.5.1"
     supports-color "3.1.2"
 
-mockery@^2.0.0:
-  version "2.0.0"
-  resolved "http://npm.valudio.com/mockery/-/mockery-2.0.0.tgz#0569a11a1848461fdc347cf8cca2df2f3129bc03"
+mockery@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/mockery/-/mockery-2.1.0.tgz#5b0aef1ff564f0f8139445e165536c7909713470"
 
 ms@0.7.2:
   version "0.7.2"
   resolved "https://registry.yarnpkg.com/ms/-/ms-0.7.2.tgz#ae25cf2512b3885a1d95d7f037868d8431124765"
 
-ms@0.7.3:
-  version "0.7.3"
-  resolved "https://registry.yarnpkg.com/ms/-/ms-0.7.3.tgz#708155a5e44e33f5fd0fc53e81d0d40a91be1fff"
+ms@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
 
 multimatch@^2.0.0:
   version "2.1.0"
@@ -1588,8 +1598,8 @@ node.extend@~1.1.2:
     is "^3.1.0"
 
 normalize-package-data@^2.3.2:
-  version "2.3.8"
-  resolved "https://registry.yarnpkg.com/normalize-package-data/-/normalize-package-data-2.3.8.tgz#d819eda2a9dedbd1ffa563ea4071d936782295bb"
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/normalize-package-data/-/normalize-package-data-2.4.0.tgz#12f95a307d58352075a04907b84ac8be98ac012f"
   dependencies:
     hosted-git-info "^2.1.4"
     is-builtin-module "^1.0.0"
@@ -1612,9 +1622,9 @@ number-is-nan@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/number-is-nan/-/number-is-nan-1.0.1.tgz#097b602b53422a522c1afb8790318336941a011d"
 
-nyc@^11.0.2:
-  version "11.0.2"
-  resolved "https://registry.yarnpkg.com/nyc/-/nyc-11.0.2.tgz#9e592a697186028253b668516c38f079c39c08f3"
+nyc@^11.0.3:
+  version "11.0.3"
+  resolved "https://registry.yarnpkg.com/nyc/-/nyc-11.0.3.tgz#0c28bc669a851621709bf7a08503034bee3812b6"
   dependencies:
     archy "^1.0.0"
     arrify "^1.0.1"
@@ -1628,7 +1638,7 @@ nyc@^11.0.2:
     glob "^7.0.6"
     istanbul-lib-coverage "^1.1.1"
     istanbul-lib-hook "^1.0.7"
-    istanbul-lib-instrument "^1.7.2"
+    istanbul-lib-instrument "^1.7.3"
     istanbul-lib-report "^1.1.1"
     istanbul-lib-source-maps "^1.2.1"
     istanbul-reports "^1.1.1"
@@ -1639,7 +1649,7 @@ nyc@^11.0.2:
     resolve-from "^2.0.0"
     rimraf "^2.5.4"
     signal-exit "^3.0.1"
-    spawn-wrap "^1.3.6"
+    spawn-wrap "^1.3.7"
     test-exclude "^4.1.1"
     yargs "^8.0.1"
     yargs-parser "^5.0.0"
@@ -1826,7 +1836,7 @@ process-nextick-args@^1.0.6, process-nextick-args@~1.0.6:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-1.0.7.tgz#150e20b756590ad3f91093f25a4f2ad8bff30ba3"
 
-pseudomap@^1.0.1:
+pseudomap@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/pseudomap/-/pseudomap-1.0.2.tgz#f052a28da70e618917ef0a8ac34c1ae5a68286b3"
 
@@ -1842,6 +1852,10 @@ qs@~6.4.0:
   version "6.4.0"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.4.0.tgz#13e26d28ad6b0ffaa91312cd3bf708ed351e7233"
 
+querystringify@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/querystringify/-/querystringify-1.0.0.tgz#6286242112c5b712fa654e526652bf6a13ff05cb"
+
 queue@^3.0.10, queue@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/queue/-/queue-3.1.0.tgz#6c49d01f009e2256788789f2bffac6b8b9990585"
@@ -1849,11 +1863,11 @@ queue@^3.0.10, queue@^3.1.0:
     inherits "~2.0.0"
 
 randomatic@^1.1.3:
-  version "1.1.6"
-  resolved "https://registry.yarnpkg.com/randomatic/-/randomatic-1.1.6.tgz#110dcabff397e9dcff7c0789ccc0a49adf1ec5bb"
+  version "1.1.7"
+  resolved "https://registry.yarnpkg.com/randomatic/-/randomatic-1.1.7.tgz#c7abe9cc8b87c0baa876b19fde83fd464797e38c"
   dependencies:
-    is-number "^2.0.2"
-    kind-of "^3.0.2"
+    is-number "^3.0.0"
+    kind-of "^4.0.0"
 
 read-pkg-up@^1.0.1:
   version "1.0.1"
@@ -1895,15 +1909,15 @@ read-pkg@^2.0.0:
     string_decoder "~0.10.x"
 
 readable-stream@^2.0.0, readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.4, readable-stream@^2.0.5, readable-stream@^2.1.5:
-  version "2.2.9"
-  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.2.9.tgz#cf78ec6f4a6d1eb43d26488cac97f042e74b7fc8"
+  version "2.3.3"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.3.tgz#368f2512d79f9d46fdfc71349ae7878bbc1eb95c"
   dependencies:
-    buffer-shims "~1.0.0"
     core-util-is "~1.0.0"
-    inherits "~2.0.1"
+    inherits "~2.0.3"
     isarray "~1.0.0"
     process-nextick-args "~1.0.6"
-    string_decoder "~1.0.0"
+    safe-buffer "~5.1.1"
+    string_decoder "~1.0.3"
     util-deprecate "~1.0.1"
 
 readable-stream@~1.1.9:
@@ -1933,8 +1947,8 @@ regex-cache@^0.4.2:
     is-primitive "^2.0.0"
 
 remove-trailing-separator@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/remove-trailing-separator/-/remove-trailing-separator-1.0.1.tgz#615ebb96af559552d4bf4057c8436d486ab63cc4"
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/remove-trailing-separator/-/remove-trailing-separator-1.0.2.tgz#69b062d978727ad14dc6b56ba4ab772fd8d70511"
 
 repeat-element@^1.1.2:
   version "1.1.2"
@@ -2018,6 +2032,10 @@ require-main-filename@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-1.0.1.tgz#97f717b69d48784f5f526a6c5aa8ffdda055a4d1"
 
+requires-port@1.0.x:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
+
 resolve-from@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-2.0.0.tgz#9480ab20e94ffa1d9e80a804c7ea147611966b57"
@@ -2040,9 +2058,9 @@ rimraf@2, rimraf@^2.3.3, rimraf@^2.5.4, rimraf@^2.6.1:
   dependencies:
     glob "^7.0.5"
 
-safe-buffer@^5.0.1:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.0.1.tgz#d263ca54696cd8a306b5ca6551e92de57918fbe7"
+safe-buffer@^5.0.1, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.1.tgz#893312af69b2123def71f57889001671eeb2c853"
 
 samsam@1.x, samsam@^1.1.3:
   version "1.2.1"
@@ -2068,9 +2086,9 @@ signal-exit@^3.0.0, signal-exit@^3.0.1, signal-exit@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
 
-sinon@^2.3.4:
-  version "2.3.4"
-  resolved "https://registry.yarnpkg.com/sinon/-/sinon-2.3.4.tgz#466ad8d1bae86d6db51aa218b92e997bc3e5db88"
+sinon@^2.3.6:
+  version "2.3.6"
+  resolved "https://registry.yarnpkg.com/sinon/-/sinon-2.3.6.tgz#95378e7e0f976a9712e9b4591ff5b39e73dc3dde"
   dependencies:
     diff "^3.1.0"
     formatio "1.2.0"
@@ -2111,9 +2129,9 @@ sparkles@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/sparkles/-/sparkles-1.0.0.tgz#1acbbfb592436d10bbe8f785b7cc6f82815012c3"
 
-spawn-wrap@^1.3.6:
-  version "1.3.6"
-  resolved "https://registry.yarnpkg.com/spawn-wrap/-/spawn-wrap-1.3.6.tgz#ccec4a949d8ce7e2b1a35cf4671d683d2e76a1d1"
+spawn-wrap@^1.3.7:
+  version "1.3.8"
+  resolved "https://registry.yarnpkg.com/spawn-wrap/-/spawn-wrap-1.3.8.tgz#fa2a79b990cbb0bb0018dca6748d88367b19ec31"
   dependencies:
     foreground-child "^1.5.6"
     mkdirp "^0.5.0"
@@ -2143,8 +2161,8 @@ split@0.3:
     through "2"
 
 sshpk@^1.7.0:
-  version "1.13.0"
-  resolved "https://registry.yarnpkg.com/sshpk/-/sshpk-1.13.0.tgz#ff2a3e4fd04497555fed97b39a0fd82fafb3a33c"
+  version "1.13.1"
+  resolved "https://registry.yarnpkg.com/sshpk/-/sshpk-1.13.1.tgz#512df6da6287144316dc4c18fe1cf1d940739be3"
   dependencies:
     asn1 "~0.2.3"
     assert-plus "^1.0.0"
@@ -2153,7 +2171,6 @@ sshpk@^1.7.0:
   optionalDependencies:
     bcrypt-pbkdf "^1.0.0"
     ecc-jsbn "~0.1.1"
-    jodid25519 "^1.0.0"
     jsbn "~0.1.0"
     tweetnacl "~0.14.0"
 
@@ -2190,21 +2207,21 @@ string-width@^1.0.1:
     strip-ansi "^3.0.0"
 
 string-width@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-2.0.0.tgz#635c5436cc72a6e0c387ceca278d4e2eec52687e"
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-2.1.0.tgz#030664561fc146c9423ec7d978fe2457437fe6d0"
   dependencies:
     is-fullwidth-code-point "^2.0.0"
-    strip-ansi "^3.0.0"
+    strip-ansi "^4.0.0"
 
 string_decoder@~0.10.x:
   version "0.10.31"
   resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-0.10.31.tgz#62e203bc41766c6c28c9fc84301dab1c5310fa94"
 
-string_decoder@~1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.0.0.tgz#f06f41157b664d86069f84bdbdc9b0d8ab281667"
+string_decoder@~1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.0.3.tgz#0fc67d7c141825de94282dd536bec6b9bce860ab"
   dependencies:
-    buffer-shims "~1.0.0"
+    safe-buffer "~5.1.0"
 
 stringstream@~0.0.4:
   version "0.0.5"
@@ -2215,6 +2232,12 @@ strip-ansi@^3.0.0, strip-ansi@^3.0.1:
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-3.0.1.tgz#6a385fb8853d952d5ff05d0e8aaf94278dc63dcf"
   dependencies:
     ansi-regex "^2.0.0"
+
+strip-ansi@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-4.0.0.tgz#a8479022eb1ac368a871389b635262c505ee368f"
+  dependencies:
+    ansi-regex "^3.0.0"
 
 strip-bom-stream@^1.0.0:
   version "1.0.0"
@@ -2295,8 +2318,8 @@ through@2, through@~2.3, through@~2.3.1:
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
 
 time-stamp@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/time-stamp/-/time-stamp-1.0.1.tgz#9f4bd23559c9365966f3302dbba2b07c6b99b151"
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/time-stamp/-/time-stamp-1.1.0.tgz#764a5a11af50561921b133f3b44e618687e0f5c3"
 
 to-absolute-glob@^0.1.1:
   version "0.1.1"
@@ -2322,9 +2345,9 @@ tslib@^1.7.1:
   version "1.7.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.7.1.tgz#bc8004164691923a79fe8378bbeb3da2017538ec"
 
-tslint@^5.4.3:
-  version "5.4.3"
-  resolved "https://registry.yarnpkg.com/tslint/-/tslint-5.4.3.tgz#761c8402b80e347b7733a04390a757b253580467"
+tslint@^5.5.0:
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/tslint/-/tslint-5.5.0.tgz#10e8dab3e3061fa61e9442e8cee3982acf20a6aa"
   dependencies:
     babel-code-frame "^6.22.0"
     colors "^1.1.2"
@@ -2335,11 +2358,13 @@ tslint@^5.4.3:
     resolve "^1.3.2"
     semver "^5.3.0"
     tslib "^1.7.1"
-    tsutils "^2.3.0"
+    tsutils "^2.5.1"
 
-tsutils@^2.3.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-2.3.0.tgz#96e661d7c2363f31adc8992ac67bbe7b7fc175e5"
+tsutils@^2.5.1:
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-2.5.1.tgz#c2001390c79eec1a5ccfa7ac12d599639683e0cf"
+  dependencies:
+    tslib "^1.7.1"
 
 tunnel-agent@^0.6.0:
   version "0.6.0"
@@ -2363,13 +2388,13 @@ type-detect@^4.0.0:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.3.tgz#0e3f2670b44099b0b46c284d136a7ef49c74c2ea"
 
-typescript@^2.3.4:
-  version "2.3.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.3.4.tgz#3d38321828231e434f287514959c37a82b629f42"
+typescript@^2.4.1:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.4.1.tgz#c3ccb16ddaa0b2314de031e7e6fee89e5ba346bc"
 
 uglify-js@^2.6:
-  version "2.8.24"
-  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-2.8.24.tgz#48eb5175cf32e22ec11a47e638d7c8b4e0faf2dd"
+  version "2.8.29"
+  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-2.8.29.tgz#29c5733148057bb4e1f75df35b7a9cb72e6a59dd"
   dependencies:
     source-map "~0.5.1"
     yargs "~3.10.0"
@@ -2387,6 +2412,13 @@ unique-stream@^2.0.2:
     json-stable-stringify "^1.0.0"
     through2-filter "^2.0.0"
 
+url-parse@^1.1.9:
+  version "1.1.9"
+  resolved "https://registry.yarnpkg.com/url-parse/-/url-parse-1.1.9.tgz#c67f1d775d51f0a18911dd7b3ffad27bb9e5bd19"
+  dependencies:
+    querystringify "~1.0.0"
+    requires-port "1.0.x"
+
 urlgrey@0.4.4:
   version "0.4.4"
   resolved "https://registry.yarnpkg.com/urlgrey/-/urlgrey-0.4.4.tgz#892fe95960805e85519f1cd4389f2cb4cbb7652f"
@@ -2396,8 +2428,8 @@ util-deprecate@~1.0.1:
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
 
 uuid@^3.0.0:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.0.1.tgz#6544bba2dfda8c1cf17e629a3a305e2bb1fee6c1"
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.1.0.tgz#3dd3d3e790abc24d7b0d3a034ffababe28ebbc04"
 
 vali-date@^1.0.0:
   version "1.0.0"
@@ -2480,9 +2512,9 @@ vinyl@~2.0.1:
     remove-trailing-separator "^1.0.1"
     replace-ext "^1.0.0"
 
-vscode@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/vscode/-/vscode-1.1.0.tgz#b04c2399b6ec768135c9688e7873d776e28dcb95"
+vscode@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/vscode/-/vscode-1.1.2.tgz#18a29e742853cd53f3c1477aec28a72895721dc9"
   dependencies:
     glob "^7.1.1"
     gulp-chmod "^2.0.0"
@@ -2496,6 +2528,7 @@ vscode@^1.1.0:
     request "^2.79.0"
     semver "^5.3.0"
     source-map-support "^0.4.11"
+    url-parse "^1.1.9"
     vinyl-source-stream "^1.1.0"
 
 which-module@^2.0.0:
@@ -2547,7 +2580,7 @@ y18n@^3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-3.2.1.tgz#6d15fba884c08679c0d77e88e7759e811e07fa41"
 
-yallist@^2.0.0:
+yallist@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-2.1.2.tgz#1c11f9218f076089a47dd512f93c6699a6a81d52"
 
@@ -2564,8 +2597,8 @@ yargs-parser@^7.0.0:
     camelcase "^4.1.0"
 
 yargs@^8.0.1:
-  version "8.0.1"
-  resolved "https://registry.yarnpkg.com/yargs/-/yargs-8.0.1.tgz#420ef75e840c1457a80adcca9bc6fa3849de51aa"
+  version "8.0.2"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-8.0.2.tgz#6299a9055b1cefc969ff7e79c1d918dceb22c360"
   dependencies:
     camelcase "^4.1.0"
     cliui "^3.2.0"


### PR DESCRIPTION
Updating dependencies, excluding `@types/node`, until releases reaches stability.

Also, fixes issue with using `valudio` as `npm` package registry.
@robertohuertasm we should avoid using it.
