### PR TITLE
Drop support for vscode prior of version 1.8.1.

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -3,9 +3,9 @@ environment:
   # Define versions of Node.js
   matrix:
     - node_js: ''
-    - node_js: 7.4.0 # vscode 1.13.-insiders
-    - node_js: 6 # vscode > 1.6.1
-    - node_js: 6.5.0 # vscode 1.6.1
+    - node_js: 7.4.0 # vscode latest insiders
+    - node_js: 6 # vscode > 1.8.1
+    - node_js: 6.5.0 # vscode 1.8.1
 matrix:
   fast_finish: true
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,8 @@ os:
 node_js:
   - node # latest node
   - 7.4.0 # vscode latest insiders
-  - 6 # vscode > 1.6.1
-  - 6.5.0 # vscode 1.6.1
+  - 6 # vscode > 1.8.1
+  - 6.5.0 # vscode 1.8.1
 matrix:
   allow_failures:
     - node_js: node

--- a/README.md
+++ b/README.md
@@ -22,8 +22,7 @@
 [![Average time to resolve an issue](https://isitmaintained.com/badge/resolution/vscode-icons/vscode-icons.svg)](https://isitmaintained.com/project/vscode-icons/vscode-icons "Average time to resolve an issue")
 [![Percentage of issues still open](https://isitmaintained.com/badge/open/vscode-icons/vscode-icons.svg)](https://isitmaintained.com/project/vscode-icons/vscode-icons "Percentage of issues still open")
 
-
-Bring icons to your VS Code.
+Bring icons to your [Visual Studio Code](https://code.visualstudio.com/) (**minimum supported version: `1.8.1`**) 
 
 ![demo](https://raw.githubusercontent.com/vscode-icons/vscode-icons/master/images/screenshot.gif)
 

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
         "email": "roberto.huertas@outlook.com"
     },
     "engines": {
-        "vscode": "^1.6.1",
+        "vscode": "^1.8.1",
         "node": ">=6.5.0"
     },
     "categories": [

--- a/src/vscode.d.ts
+++ b/src/vscode.d.ts
@@ -4,6 +4,5 @@ import { IVSIcons } from './models/contributions';
 declare module 'vscode' {
   interface WorkspaceConfiguration {
     vsicons: IVSIcons;
-    inspect<T>(section: string): {defaultValue: T, globalValue: T, key: string, workspaceValue: T} | undefined;
   }
 }


### PR DESCRIPTION
Dropping support of `vscode` versions prior of `1.8.1`.