### PR TITLE
test verifying altered order won't trigger config changes

### DIFF
--- a/test/init/applyCustomizationsManager.test.ts
+++ b/test/init/applyCustomizationsManager.test.ts
@@ -127,10 +127,10 @@ describe('ApplyCustomizations: tests', function () {
           { icon: "js", extensions: ["myExt1", "myExt2.custom.js"], format: "svg" },
           { icon: "js2", extensions: ["myExt1", "myExt2.custom.js"], format: "svg" },
         ];
-        const newConfig = { ...userConfig, associations: { ...userConfig.associations } };
-        newConfig.associations.files = [...userConfig.associations.files];
-        newConfig.associations.files.reverse();
-        manageApplyCustomizations(newConfig, userConfig, spy);
+        const initConfig = { ...userConfig, associations: { ...userConfig.associations } };
+        initConfig.associations.files = [...userConfig.associations.files];
+        userConfig.associations.files.reverse();
+        manageApplyCustomizations(initConfig, userConfig, spy);
         expect(spy.called).to.not.be.true;
       });
 

--- a/test/init/applyCustomizationsManager.test.ts
+++ b/test/init/applyCustomizationsManager.test.ts
@@ -130,8 +130,7 @@ describe('ApplyCustomizations: tests', function () {
         const newConfig = { ...userConfig, associations: { ...userConfig.associations } };
         newConfig.associations.files = [...userConfig.associations.files];
         newConfig.associations.files.reverse();
-        const initConfig = JSON.parse(JSON.stringify(newConfig));
-        manageApplyCustomizations(initConfig, userConfig, spy);
+        manageApplyCustomizations(newConfig, userConfig, spy);
         expect(spy.called).to.not.be.true;
       });
 

--- a/test/init/applyCustomizationsManager.test.ts
+++ b/test/init/applyCustomizationsManager.test.ts
@@ -120,6 +120,21 @@ describe('ApplyCustomizations: tests', function () {
         expect(spy.called).to.not.be.true;
       });
 
+    it('if the configuration has only moved its elements, the callback will not be called',
+      function () {
+        const spy = sinon.spy();
+        userConfig.associations.files = [
+          { icon: "js", extensions: ["myExt1", "myExt2.custom.js"], format: "svg" },
+          { icon: "js2", extensions: ["myExt1", "myExt2.custom.js"], format: "svg" },
+        ];
+        const newConfig = { ...userConfig, associations: { ...userConfig.associations } };
+        newConfig.associations.files = [...userConfig.associations.files];
+        newConfig.associations.files.reverse();
+        const initConfig = JSON.parse(JSON.stringify(newConfig));
+        manageApplyCustomizations(initConfig, userConfig, spy);
+        expect(spy.called).to.not.be.true;
+      });
+
     it('if the user disables the showing of the manually changed configuration message, ' +
       'the callback will not be called',
       function () {


### PR DESCRIPTION
Related to #1072.

If we introduce the proposed change then order alterations will trigger change detection. That's why `intersectionWith` was being used. I've added the test so we won't miss this next time.
