### PR TITLE
Fix the version format for the default state.

### DIFF
--- a/.bithoundrc
+++ b/.bithoundrc
@@ -1,8 +1,8 @@
 {
   "ignore": [
-    "**/.vscode/**",
     "**/node_modules/**",
-    "**/out/**"
+    "**/out/**",
+    "**/src/*.d.ts"
   ],
   "test": [
     "**/test/**"

--- a/src/settings/settingsManager.ts
+++ b/src/settings/settingsManager.ts
@@ -39,21 +39,20 @@ export class SettingsManager implements ISettingsManager {
 
   public getState(): IState {
     const defaultState: IState = {
-      version: '0',
+      version: '0.0.0',
       status: ExtensionStatus.notActivated,
       welcomeShown: false,
     };
-
-    let state;
+    if (!fs.existsSync(this.settings.settingsPath)) {
+      return defaultState;
+    }
     try {
-      state = fs.readFileSync(this.settings.settingsPath, 'utf8');
+      const state = fs.readFileSync(this.settings.settingsPath, 'utf8');
+      return (parseJSON(state) as IState) || defaultState;
     } catch (error) {
       console.error(error);
       return defaultState;
     }
-
-    const json: IState = parseJSON(state);
-    return json || defaultState;
   }
 
   public setState(state: IState): void {

--- a/test/settings/settings.test.ts
+++ b/test/settings/settings.test.ts
@@ -103,7 +103,7 @@ describe('SettingsManager: tests', function () {
       function () {
         const writeToFile = sandbox.stub(fs, 'writeFileSync');
         const stateMock: IState = {
-          version: '0',
+          version: '0.0.0',
           status: ExtensionStatus.notActivated,
           welcomeShown: false,
         };
@@ -138,8 +138,13 @@ describe('SettingsManager: tests', function () {
 
       it('returns the state from the settings file',
         function () {
-          const stateMock = '{ "version": "1.0.0", "status": 0, "welcomeShown": true}';
-          sandbox.stub(fs, 'readFileSync').returns(stateMock);
+          const stateMock: IState = {
+            version: "1.0.0",
+            status: ExtensionStatus.enabled,
+            welcomeShown: true,
+          };
+          sandbox.stub(fs, 'existsSync').returns(true);
+          sandbox.stub(fs, 'readFileSync').returns(JSON.stringify(stateMock));
           const state = settingsManager.getState();
           expect(state).to.be.an.instanceOf(Object);
           expect(state).to.have.all.keys('version', 'status', 'welcomeShown');
@@ -148,19 +153,29 @@ describe('SettingsManager: tests', function () {
 
       it('returns a default state if no settings file exists',
         function () {
-          sandbox.stub(fs, 'readFileSync').returns('test');
+          sandbox.stub(fs, 'existsSync').returns(false);
           const state = settingsManager.getState();
           expect(state).to.be.instanceOf(Object);
-          expect(state.version).to.be.equal('0');
+          expect(state.version).to.be.equal('0.0.0');
         });
 
       it('returns a default state if reading the file fails',
         function () {
+          sandbox.stub(fs, 'existsSync').returns(true);
           sandbox.stub(fs, 'readFileSync').throws(Error);
           sandbox.stub(console, 'error');
           const state = settingsManager.getState();
           expect(state).to.be.instanceOf(Object);
-          expect(state.version).to.be.equal('0');
+          expect(state.version).to.be.equal('0.0.0');
+        });
+
+      it('returns a default state if parsing the file content fails',
+        function () {
+          sandbox.stub(fs, 'existsSync').returns(true);
+          sandbox.stub(fs, 'readFileSync').returns('test');
+          const state = settingsManager.getState();
+          expect(state).to.be.instanceOf(Object);
+          expect(state.version).to.be.equal('0.0.0');
         });
 
     });
@@ -169,7 +184,11 @@ describe('SettingsManager: tests', function () {
 
       it('truthy for a new extension version',
         function () {
-          const stateMock = { version: "1.0.0", status: 2, welcomeShown: true };
+          const stateMock: IState = {
+            version: "1.0.0",
+            status: ExtensionStatus.notActivated,
+            welcomeShown: true,
+          };
           const getState = sinon.stub(settingsManager, 'getState').returns(stateMock);
           settingsManager.getSettings();
           expect(settingsManager.isNewVersion()).to.be.true;
@@ -178,7 +197,11 @@ describe('SettingsManager: tests', function () {
 
       it('falsy for the same extension version',
         function () {
-          const stateMock = { version: extensionSettings.version, status: 2, welcomeShown: true };
+          const stateMock: IState = {
+            version: extensionSettings.version,
+            status: ExtensionStatus.notActivated,
+            welcomeShown: true,
+          };
           const getState = sinon.stub(settingsManager, 'getState').returns(stateMock);
           settingsManager.getSettings();
           expect(settingsManager.isNewVersion()).to.be.false;
@@ -187,7 +210,11 @@ describe('SettingsManager: tests', function () {
 
       it('falsy for an older extension version',
         function () {
-          const stateMock = { version: "100.0.0", status: 2, welcomeShown: true };
+          const stateMock: IState = {
+            version: "100.0.0",
+            status: ExtensionStatus.notActivated,
+            welcomeShown: true,
+          };
           const getState = sinon.stub(settingsManager, 'getState').returns(stateMock);
           settingsManager.getSettings();
           expect(settingsManager.isNewVersion()).to.be.false;


### PR DESCRIPTION
***Fixes #1097***

**Changes proposed:**
* [x] Fix

**Things I've done:**
* [x] My pull request fixes an issue, I referenced the issue.

We were not using valid `SemVer` version for the default state.
