### PR TITLE
Docker Images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,0 @@
-FROM node:slim
-WORKDIR /app
-COPY package.json /app
-RUN npm install -d
-COPY . /app
-CMD ["npm", "run", "build"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM node:8.7.0-alpine
+ENV npm_package_engines_vscode=^1.8.1
+WORKDIR /app
+RUN apk add --update git && \
+    rm -rf /tmp/* /var/cache/apk/*
+COPY . /app
+CMD [ "sh", "./docker/development/build.sh" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,0 @@
-FROM node:8.7.0-alpine
-ENV npm_package_engines_vscode=^1.8.1
-WORKDIR /app
-RUN apk add --update git && \
-    rm -rf /tmp/* /var/cache/apk/*
-COPY . /app
-CMD [ "sh", "./docker/development/build.sh" ]

--- a/README.md
+++ b/README.md
@@ -385,14 +385,10 @@ npm run build
 
 ### Building the extension's source code via docker
 
-Make sure that you have docker installed.
+Make sure that you have docker installed and follow one of the links below:
 
-```sh
-docker build -t vscode-icons .
-docker run --rm -it -v $PWD/dist:/app/dist vscode-icons
-```
-
-All of the files will be generated in the `dist` folder.
+[If you want to develop or build the app](https://github.com/vscode-icons/vscode-icons/blob/master/docker/development/README.md).
+[If you want to get the result of the latest published build](https://github.com/vscode-icons/vscode-icons/blob/master/docker/remote-builder/README.md)
 
 ## Change log
 
@@ -402,6 +398,10 @@ If you feel that there's some icon missing please report it to the Github reposi
 
 ## Versioning
 
-vscode-icons follows [Semantic Versioning 2.0.0](http://semver.org/).
+`vscode-icons` follows [Semantic Versioning 2.0.0](http://semver.org/).
+
+## Related extensions
+
+- [vscode-icons for GitHub](https://github.com/dderevjanik/github-vscode-icons) by [@dderevjanik](https://github.com/dderevjanik) will allow you to see all `Github`'s files with `vscode-icons` icons.
 
 **Enjoy!**

--- a/docker/development/Dockerfile
+++ b/docker/development/Dockerfile
@@ -1,0 +1,8 @@
+FROM node:8.7.0-alpine
+ENV npm_package_engines_vscode=^1.8.1
+RUN apk add --update git && \
+    rm -rf /tmp/* /var/cache/apk/*
+VOLUME [ "/app" ]
+WORKDIR /app
+
+CMD [ "sh", "./docker/development/build.sh" ]

--- a/docker/development/README.md
+++ b/docker/development/README.md
@@ -1,0 +1,34 @@
+# development
+
+If you want to **build** the project you can do this:
+
+```sh
+# First, build the image if not already build.
+# This should be a one time command.
+docker build -t dev docker/development
+
+# Then run it.
+# Note that we're using a volume to have access to the artifact in our host.
+# Here we're using a Docker for Windows mapping. If you're using other OS then take a look at https://docs.docker.com/engine/admin/volumes/volumes/.
+# Once the container is done it will automatically be removed and the artifact will be in your mapped folder.
+docker run --rm -it -v d:/GIT/github/robertohuertasm/vscode-icons:/app dev
+
+# Finally, if you want to clean the stale volumes you can run this.
+docker volume rm $(docker volume ls -qf dangling=true)
+```
+
+If you want to use `Docker` in order to **develop** you can do this:
+
+```sh
+# First, build the image if not already build.
+# This should be a one time command.
+docker build -t dev docker/development
+
+# Then run it.
+# Note that we're using a volume to have access to the artifact in our host.
+# Here we're using a Docker for Windows mapping. If you're using other OS then take a look at https://docs.docker.com/engine/admin/volumes/volumes/.
+docker run -it -v d:/GIT/github/robertohuertasm/vscode-icons:/app dev sh
+
+# Finally, if you want to clean the stale volumes you can run this.
+docker volume rm $(docker volume ls -qf dangling=true)
+```

--- a/docker/development/README.md
+++ b/docker/development/README.md
@@ -8,10 +8,9 @@ If you want to **build** the project you can do this:
 docker build -t dev docker/development
 
 # Then run it.
-# Note that we're using a volume to have access to the artifact in our host.
-# Here we're using a Docker for Windows mapping. If you're using other OS then take a look at https://docs.docker.com/engine/admin/volumes/volumes/.
+# Note that we're using a volume to have access to the artifact in our host (https://docs.docker.com/engine/admin/volumes/volumes/).
 # Once the container is done it will automatically be removed and the artifact will be in your mapped folder.
-docker run --rm -it -v d:/GIT/github/robertohuertasm/vscode-icons:/app dev
+docker run --rm -it -v <your-host-path-here>:/app dev
 
 # Finally, if you want to clean the stale volumes you can run this.
 docker volume rm $(docker volume ls -qf dangling=true)
@@ -25,9 +24,8 @@ If you want to use `Docker` in order to **develop** you can do this:
 docker build -t dev docker/development
 
 # Then run it.
-# Note that we're using a volume to have access to the artifact in our host.
-# Here we're using a Docker for Windows mapping. If you're using other OS then take a look at https://docs.docker.com/engine/admin/volumes/volumes/.
-docker run -it -v d:/GIT/github/robertohuertasm/vscode-icons:/app dev sh
+# Note that we're using a volume to have access to the artifact in our host (https://docs.docker.com/engine/admin/volumes/volumes/).
+docker run -it -v <your-host-path-here>:/app dev sh
 
 # Finally, if you want to clean the stale volumes you can run this.
 docker volume rm $(docker volume ls -qf dangling=true)

--- a/docker/development/build.sh
+++ b/docker/development/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+. docker/development/install.sh
+npm run build

--- a/docker/development/install.sh
+++ b/docker/development/install.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+npm i
+node node_modules/vscode/bin/install

--- a/docker/remote-builder/Dockerfile
+++ b/docker/remote-builder/Dockerfile
@@ -1,0 +1,9 @@
+FROM node:8.7.0-alpine
+ENV npm_package_engines_vscode=^1.8.1
+RUN apk add --update git && \
+    rm -rf /tmp/* /var/cache/apk/*
+RUN git clone https://github.com/vscode-icons/vscode-icons.git app
+VOLUME [ "/app-out" ]
+WORKDIR /app
+COPY build.sh .
+CMD [ "sh", "./build.sh" ]

--- a/docker/remote-builder/README.md
+++ b/docker/remote-builder/README.md
@@ -16,10 +16,9 @@ Assuming you're in the root folder:
 docker build -t vsi docker/remote-builder
 
 # Then run it.
-# Note that we're using a volume to have access to the artifact in our host.
-# Here we're using a Docker for Windows mapping. If you're using other OS then take a look at https://docs.docker.com/engine/admin/volumes/volumes/.
+# Note that we're using a volume to have access to the artifact in our host (https://docs.docker.com/engine/admin/volumes/volumes/).
 # Once the container is done it will automatically be removed and the artifact will be in your mapped folder.
-docker run --rm -it -v c:/Users/Roberto/Desktop/s/shared:/app-out vsi
+docker run --rm -it -v <your-host-path-here>:/app-out vsi
 
 # Finally, if you want to clean the stale volumes you can run this.
 docker volume rm $(docker volume ls -qf dangling=true)

--- a/docker/remote-builder/README.md
+++ b/docker/remote-builder/README.md
@@ -1,0 +1,26 @@
+# remote-builder
+
+The purpose of this image is to be run and get the artifact from building the extension.
+
+Note that the repo will be cloned directly from Github so it will be working always with the latest published version.
+
+This image was originally created to make it easier to consume the latest version of `icon.json` file in order to build the amazing [github-vscode-icons extension](https://github.com/dderevjanik/github-vscode-icons) by [@dderevjanik](https://github.com/dderevjanik).
+
+## How to use it
+
+Assuming you're in the root folder:
+
+```sh
+# First, build the image if not already build.
+# This should be a one time command.
+docker build -t vsi docker/remote-builder
+
+# Then run it.
+# Note that we're using a volume to have access to the artifact in our host.
+# Here we're using a Docker for Windows mapping. If you're using other OS then take a look at https://docs.docker.com/engine/admin/volumes/volumes/.
+# Once the container is done it will automatically be removed and the artifact will be in your mapped folder.
+docker run --rm -it -v c:/Users/Roberto/Desktop/s/shared:/app-out vsi
+
+# Finally, if you want to clean the stale volumes you can run this.
+docker volume rm $(docker volume ls -qf dangling=true)
+```

--- a/docker/remote-builder/build.sh
+++ b/docker/remote-builder/build.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+git pull
+npm i
+node node_modules/vscode/bin/install
+npm run build
+cp -R out/src/* ../app-out


### PR DESCRIPTION
Just improved the docker images:

- reduced file size by using `node:alpine`.
- fixed issue with `vscode.d.ts` error when using some linux docker images.
- added a docker image in order to get the latest artifact from the published version, not the local. This may be useful for cases like [vscode-icons for Github](https://github.com/dderevjanik/github-vscode-icons) extension where the author requires the latest `icons.json` file.

//cc @dderevjanik