### PR TITLE
taskname has been deprecated

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -5,7 +5,7 @@
   "version": "2.0.0",
   "tasks": [
     {
-      "taskName": "npm",
+      "label": "npm",
       // the command is a shell script
       "type": "shell",
       // we want to run npm


### PR DESCRIPTION
`taskName` changed by `label`.
Related to [#1330](https://github.com/vscode-icons/vscode-icons/pull/1330#issuecomment-341984132)
