### PR TITLE
Update Yarn version in CI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,9 @@ node_js:
 matrix:
   allow_failures:
     - node_js: node
+before_install:
+  - curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.3.2
+  - export PATH=$HOME/.yarn/bin:$PATH
 cache: yarn
 script: npm run build
 after_success:


### PR DESCRIPTION
`Travis CI` pre-build containers use `Yarn v0.27.5` which is outdated by far.
This PR forces `Travis CI` to use version `1.3.2` which by the time this is written is the latest.