### PR TITLE
Fix project autodetection on standalone files

### DIFF
--- a/src/init/projectAutoDetection.ts
+++ b/src/init/projectAutoDetection.ts
@@ -54,12 +54,14 @@ export class ProjectAutoDetection {
 
   public static getProjectInfo(results: models.IVSCodeUri[], name: models.Projects): models.IProjectInfo {
     let projectInfo: models.IProjectInfo = null;
-    results.some(result => {
-      const content = fs.readFileSync(result.fsPath, 'utf8');
-      const projectJson = parseJSON(content);
-      projectInfo = this.getInfo(projectJson, name);
-      return !!projectInfo;
-    });
+    results
+      .filter(result => typeof result.fsPath === 'string' || Buffer.isBuffer(result.fsPath))
+      .some(result => {
+        const content = fs.readFileSync(result.fsPath, 'utf8');
+        const projectJson = parseJSON(content);
+        projectInfo = this.getInfo(projectJson, name);
+        return !!projectInfo;
+      });
     return projectInfo;
   }
 


### PR DESCRIPTION
**Changes proposed:**

- [ ] Add
- [ ] Prepare
- [ ] Delete
- [x] Fix

**Things I've done:**

- [ ] My pull request fixes an issue, I referenced the issue.

currently throws here with "path must be a string or Buffer" error.

this PR introduces a simple `Array#filter` call to guard against that.

(as an aside, this could be caught with `--strictNullChecks` enabled :) )