### PR TITLE
Add support to specify a relative path for custom icons folder path.

### DIFF
--- a/src/icon-manifest/manifestReader.ts
+++ b/src/icon-manifest/manifestReader.ts
@@ -9,7 +9,9 @@ export class ManifestReader {
   public static iconsDisabled(name: string, isFile: boolean = true): boolean {
     const iconManifest = this.getIconManifest();
     const iconsJson = iconManifest && parseJSON(iconManifest) as models.IIconSchema;
-    const defNamePattern = `_${isFile ? 'f' : 'fd'}_${name}${isFile ? '_' : ''}`;
+    const prefix = isFile ? extensionSettings.manifestFilePrefix : extensionSettings.manifestFolderPrefix;
+    const suffix = isFile ? '_' : '';
+    const defNamePattern = `${prefix}${name}${suffix}`;
     return !iconsJson || !Reflect.ownKeys(iconsJson.iconDefinitions)
       .filter(key => key.toString().startsWith(defNamePattern)).length;
   }

--- a/src/init/projectAutoDetection.ts
+++ b/src/init/projectAutoDetection.ts
@@ -5,7 +5,7 @@ import { LanguageResourceManager } from '../i18n';
 
 export class ProjectAutoDetection {
   public static detectProject(
-    findFiles: (
+    findFilesFn: (
       include: string,
       exclude: string,
       maxResults?: number,
@@ -15,7 +15,7 @@ export class ProjectAutoDetection {
       return Promise.resolve(null) as PromiseLike<models.IVSCodeUri[]>;
     }
 
-    return findFiles('**/package.json', '**/node_modules/**')
+    return findFilesFn('**/package.json', '**/node_modules/**')
       .then(results => results, rej => [rej]);
   }
 

--- a/src/models/settings/settings.ts
+++ b/src/models/settings/settings.ts
@@ -2,6 +2,7 @@ import { IExtensionSettings } from './extensionSettings';
 
 export interface ISettings {
   vscodeAppData: string; // path to the vscode app data folder
+  workspacePath: string[]; // path to the workspace folders or root folder
   isWin: boolean;
   isInsiders: boolean;
   isOSS: boolean;

--- a/src/models/vscode/index.ts
+++ b/src/models/vscode/index.ts
@@ -3,3 +3,4 @@ export *  from './vscodeCancellationToken';
 export *  from './vscodeEnv';
 export *  from './vscodeMessageItem';
 export *  from './vscodeUri';
+export *  from './vscodeWorkspace';

--- a/src/models/vscode/vscode.ts
+++ b/src/models/vscode/vscode.ts
@@ -1,6 +1,8 @@
 import { IVSCodeEnv } from './vscodeEnv';
+import { IVSCodeWorkspace } from './vscodeWorkspace';
 
 export interface IVSCode {
   env: IVSCodeEnv;
   version: string;
+  workspace: IVSCodeWorkspace;
 }

--- a/src/models/vscode/vscodeWorkspace.ts
+++ b/src/models/vscode/vscodeWorkspace.ts
@@ -1,0 +1,6 @@
+import * as vscode from 'vscode';
+
+export interface IVSCodeWorkspace {
+  rootPath?: string;
+  workspaceFolders?: vscode.WorkspaceFolder[] | undefined;
+}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -6,6 +6,7 @@ import { IVSCode, FileFormat } from '../models';
 export const vscode: IVSCode = {
   env: { appName: 'Code' },
   version: '1000.0.0',
+  workspace: {},
 };
 
 export function pathUnixJoin(...paths: string[]): string {

--- a/src/utils/vscode-extensions.ts
+++ b/src/utils/vscode-extensions.ts
@@ -1,6 +1,6 @@
 import * as _ from 'lodash';
 import * as vscode from 'vscode';
-import { IVSCodeUri, IVSIcons, IFileExtension } from '../models';
+import { IVSIcons, IFileExtension } from '../models';
 
 export function getConfig(): vscode.WorkspaceConfiguration {
   return vscode.workspace.getConfiguration();
@@ -31,6 +31,6 @@ export function findFiles(
   return vscode.workspace.findFiles(include, exclude, maxResults, token);
 }
 
-export function asRelativePath(pathOrUri: string | IVSCodeUri): string {
+export function asRelativePath(pathOrUri: string | vscode.Uri): string {
   return vscode.workspace.asRelativePath(pathOrUri);
 }

--- a/src/vscode.d.ts
+++ b/src/vscode.d.ts
@@ -5,4 +5,39 @@ declare module 'vscode' {
   interface WorkspaceConfiguration {
     vsicons: IVSIcons;
   }
+
+  // The following definitions are added to support editor versions prior of '1.15'
+  // Can be safely removed once the minimun supported `vscode` version gets greater than or equal to '1.15'
+  namespace workspace {
+    /**
+     * List of workspace folders or `undefined` when no folder is open.
+     * *Note* that the first entry corresponds to the value of `rootPath`.
+     *
+     * @readonly
+     */
+    export let workspaceFolders: WorkspaceFolder[] | undefined;
+  }
+
+  // The following definitions are added to support editor versions prior of '1.15'
+  // Can be safely removed once the minimun supported `vscode` version gets greater than or equal to '1.15'
+  interface WorkspaceFolder {
+    /**
+     * The associated uri for this workspace folder.
+     *
+     * *Note:* The [Uri](#Uri)-type was intentionally chosen such that future releases of the editor can support
+     * workspace folders that are not stored on the local disk, e.g. `ftp://server/workspaces/foo`.
+     */
+    readonly uri: Uri;
+
+    /**
+     * The name of this workspace folder. Defaults to
+     * the basename of its [uri-path](#Uri.path)
+     */
+    readonly name: string;
+
+    /**
+     * The ordinal number of this workspace folder.
+     */
+    readonly index: number;
+  }
 }

--- a/test/iconGenerator/functionality.test.ts
+++ b/test/iconGenerator/functionality.test.ts
@@ -219,7 +219,7 @@ describe('IconGenerator: functionality test', function () {
           expect(updatePackageJson.called).to.be.false;
         });
 
-      context('the \'updatePackageJson\' function', function () {
+      context('function \'updatePackageJson\'', function () {
 
         it('logs an error if something goes wrong',
           function () {
@@ -320,6 +320,32 @@ describe('IconGenerator: functionality test', function () {
           expect(iconGenerator.generateJson
             .bind(iconGenerator, emptyFileCollection, folderExtensions))
             .to.throw(Error, /Folder icons for '.*' must be placed in the same directory/);
+        });
+
+      it('uses the app data path when no custom icon folder path is specified', function () {
+        const folderPath: string = undefined;
+        const customIconFolderPath = iconGenerator.getCustomIconFolderPath(folderPath);
+        expect(customIconFolderPath).to.be.equal(iconGenerator.settings.vscodeAppData);
+      });
+
+      it('uses the provided path when a custom icon folder absolute path is specified', function () {
+        const folderPath: string = '/custom/folder/path';
+        const customIconFolderPath = iconGenerator.getCustomIconFolderPath(folderPath);
+        expect(customIconFolderPath).to.be.equal(folderPath);
+      });
+
+      it('uses the resolved absolute path from the root of the project ' +
+        'when a relative custom icon folder path is specified', function () {
+          const sandbox = sinon.sandbox.create();
+          sandbox.stub(fs, 'existsSync').returns(true);
+
+          iconGenerator.settings.workspacePath = ['/workspace/path'];
+          const folderPath: string = './custom/folder/path';
+          const customIconFolderPath = iconGenerator.getCustomIconFolderPath(folderPath);
+          const joinedPath = utils.pathUnixJoin(iconGenerator.settings.workspacePath[0], folderPath);
+          expect(customIconFolderPath).to.be.equal(joinedPath);
+
+          sandbox.restore();
         });
 
       const testCase = (belongToSameDrive: boolean) => {

--- a/test/settings/settings.test.ts
+++ b/test/settings/settings.test.ts
@@ -98,6 +98,35 @@ describe('SettingsManager: tests', function () {
 
     });
 
+    context('function \'getWorkspacePath\ returns', function () {
+
+      it('the workspace root path when \'workspaceFolders\' is not supported',
+        function () {
+          vscode.workspace.workspaceFolders = undefined;
+          vscode.workspace.rootPath = '/path/to/workspace/root';
+          const result = new SettingsManager(vscode).getWorkspacePath();
+          expect(result).to.be.an('array').with.members([vscode.workspace.rootPath]);
+        });
+
+      it('the workspace folders when \'workspaceFolders\' is supported',
+        function () {
+          const paths = ['/path/to/workspace/folder1/root', '/path/to/workspace/folder2/root'];
+          const workspaceFolder: any = { uri: {fsPath: paths[0]}};
+          const workspaceFolder1: any = { uri: {fsPath: paths[1]}};
+          vscode.workspace.workspaceFolders = [workspaceFolder, workspaceFolder1];
+          const result = new SettingsManager(vscode).getWorkspacePath();
+          expect(result).to.be.an('array').with.members(paths);
+        });
+
+      it('\'undefined\' when \'workspaceFolders\' and \'rootPath\' is undefined',
+        function () {
+          vscode.workspace.workspaceFolders = undefined;
+          vscode.workspace.rootPath = undefined;
+          const result = new SettingsManager(vscode).getWorkspacePath();
+          expect(result).to.be.undefined;
+        });
+
+    });
   });
 
   context('ensures that', function () {


### PR DESCRIPTION
<!-- markdownlint-disable MD041-->

<!-- Please first read how to submit a pull request, if you haven't already done so.
https://github.com/vscode-icons/vscode-icons/wiki/PullRequest -->

_**References #1416**_

**Changes proposed:**

- [x] Add

This PR adds the functionality to set the `vsicons.customIconFolderPath` with a relative path to the root of the opening project. This is handy when distributing custom icons with the project source code.

I have also done some code refactoring which normally should have been submitted in another PR but I'm getting lazy lately.

Also, once this PR gets merged the [wiki page](https://github.com/vscode-icons/vscode-icons/wiki/Custom) needs to be updated to include the added ability.