### PR TITLE
Updated Icon yaml to support .yaml extension

### DIFF
--- a/src/icon-manifest/supportedExtensions.ts
+++ b/src/icon-manifest/supportedExtensions.ts
@@ -608,7 +608,7 @@ export const extensions: IFileCollection = {
     { icon: 'xliff', extensions: ['xliff', 'xlf'], format: FileFormat.svg },
     { icon: 'xml', extensions: ['pex', 'tmlanguage'], languages: [languages.xml], format: FileFormat.svg },
     { icon: 'xsl', extensions: [], languages: [languages.xsl], format: FileFormat.svg },
-    { icon: 'yaml', extensions: ['yml'], light: true, languages: [languages.yaml, languages.textmateyaml], format: FileFormat.svg },
+    { icon: 'yaml', extensions: ['yml', 'yaml'], light: true, languages: [languages.yaml, languages.textmateyaml], format: FileFormat.svg },
     { icon: 'yang', extensions: [], languages: [languages.yang], format: FileFormat.svg },
     { icon: 'yarn', extensions: ['yarn.lock', '.yarnrc', '.yarnclean', '.yarn-integrity', '.yarn-metadata.json', '.yarnignore'], filename: true, format: FileFormat.svg },
     { icon: 'yeoman', extensions: ['.yo-rc.json'], filename: true, format: FileFormat.svg },


### PR DESCRIPTION
<!-- markdownlint-disable MD041-->

<!-- Please first read how to submit a pull request, if you haven't already done so.
https://github.com/vscode-icons/vscode-icons/wiki/PullRequest -->

_**Fixes #IssueNumber**_

**Changes proposed:**

- [X] Add
Added support for .yaml extension, as currently yaml icon only support .yml
![image](https://user-images.githubusercontent.com/3488643/36012560-83124262-0d24-11e8-8cfd-672d480f90e6.png)
- [ ] Delete
- [ ] Fix
- [ ] Prepare
