### PR TITLE
Apply 'esModuleInterop' configuration.

### DIFF
--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -1,4 +1,4 @@
-import * as vscode from 'vscode';
+import vscode from 'vscode';
 import { getConfig, getVsiconsConfig } from '../utils/vscode-extensions';
 import { LanguageResourceManager } from '../i18n';
 import * as iconManifest from '../icon-manifest';

--- a/src/i18n/langResourceCollection.ts
+++ b/src/i18n/langResourceCollection.ts
@@ -1,12 +1,12 @@
 // tslint:disable object-literal-key-quotes
 import { ILangResourceCollection } from '../models/i18n';
-import * as de from '../../../locale/lang.de.json';
-import * as en from '../../../locale/lang.en.json';
-import * as es from '../../../locale/lang.es.json';
-import * as fr from '../../../locale/lang.fr.json';
-import * as it from '../../../locale/lang.it.json';
-import * as ru from '../../../locale/lang.ru.json';
-import * as zhCn from '../../../locale/lang.zh-cn.json';
+import de from '../../../locale/lang.de.json';
+import en from '../../../locale/lang.en.json';
+import es from '../../../locale/lang.es.json';
+import fr from '../../../locale/lang.fr.json';
+import it from '../../../locale/lang.it.json';
+import ru from '../../../locale/lang.ru.json';
+import zhCn from '../../../locale/lang.zh-cn.json';
 
 export const langResourceCollection: ILangResourceCollection = {
   de,

--- a/src/icon-manifest/iconGenerator.ts
+++ b/src/icon-manifest/iconGenerator.ts
@@ -1,10 +1,10 @@
-import * as fs from 'fs';
-import * as path from 'path';
-import * as _ from 'lodash';
+import fs from 'fs';
+import path from 'path';
+import _ = require('lodash');
+import packageJson from '../../../package.json';
 import { SettingsManager } from '../settings';
 import * as utils from '../utils';
 import * as models from '../models';
-import * as packageJson from '../../../package.json';
 
 export class IconGenerator implements models.IIconGenerator {
   public settings: models.ISettings;

--- a/src/icon-manifest/manifestMerger.ts
+++ b/src/icon-manifest/manifestMerger.ts
@@ -1,4 +1,4 @@
-import * as _ from 'lodash';
+import _ = require('lodash');
 import * as models from '../models';
 
 export function mergeConfig(

--- a/src/icon-manifest/manifestReader.ts
+++ b/src/icon-manifest/manifestReader.ts
@@ -1,5 +1,5 @@
-import * as fs from 'fs';
-import * as path from 'path';
+import fs from 'fs';
+import path from 'path';
 import * as models from '../models';
 import { parseJSON } from '../utils';
 import { extensionSettings } from '../settings';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import * as vscode from 'vscode';
+import vscode from 'vscode';
 import { SettingsManager } from './settings';
 import * as init from './init';
 import { ProjectAutoDetection as pad } from './init/projectAutoDetection';

--- a/src/init/applyCustomizationsManager.ts
+++ b/src/init/applyCustomizationsManager.ts
@@ -1,6 +1,6 @@
-import * as _ from 'lodash';
+import _ = require('lodash');
+import packageJson from '../../../package.json';
 import { IVSIcons, IVSCodeMessageItem } from '../models';
-import * as packageJson from '../../../package.json';
 import * as utils from '../utils';
 
 export function manageAutoApplyCustomizations(

--- a/src/init/projectAutoDetection.ts
+++ b/src/init/projectAutoDetection.ts
@@ -1,4 +1,4 @@
-import * as fs from 'fs';
+import fs from 'fs';
 import * as models from '../models';
 import { parseJSON } from '../utils';
 import { LanguageResourceManager } from '../i18n';

--- a/src/init/welcome.ts
+++ b/src/init/welcome.ts
@@ -1,5 +1,5 @@
-import * as vscode from 'vscode';
-import * as open from 'open';
+import vscode from 'vscode';
+import open from 'open';
 import { LanguageResourceManager } from '../i18n';
 import { getConfig } from '../utils/vscode-extensions';
 import { ISettingsManager, LangResourceKeys } from '../models';

--- a/src/settings/settingsManager.ts
+++ b/src/settings/settingsManager.ts
@@ -1,5 +1,5 @@
-import * as fs from 'fs';
-import * as semver from 'semver';
+import fs from 'fs';
+import semver from 'semver';
 import { vscodePath as getAppPath, parseJSON, pathUnixJoin } from '../utils';
 import { ISettings, IState, IVSCode, ISettingsManager, ExtensionStatus } from '../models';
 import { extensionSettings } from './extensionSettings';

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,6 +1,6 @@
-import * as fs from 'fs';
-import * as path from 'path';
-import * as os from 'os';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
 import { IVSCode, FileFormat } from '../models';
 
 export const vscode: IVSCode = {

--- a/src/utils/vscode-extensions.ts
+++ b/src/utils/vscode-extensions.ts
@@ -1,5 +1,5 @@
-import * as _ from 'lodash';
-import * as vscode from 'vscode';
+import _ = require('lodash');
+import vscode from 'vscode';
 import { IVSIcons, IFileExtension } from '../models';
 
 export function getConfig(): vscode.WorkspaceConfiguration {

--- a/test/i18n/i18n.test.ts
+++ b/test/i18n/i18n.test.ts
@@ -4,9 +4,9 @@ import { expect } from 'chai';
 import { LanguageResourceManager } from '../../src/i18n';
 import { langResourceCollection } from '../../src/i18n/langResourceCollection';
 import { LangResourceKeys } from '../../src/models/i18n';
-import * as packageJson from '../../../package.json';
-import * as nls from '../../../package.nls.json';
-import * as nlsTemplate from '../../../package.nls.template.json';
+import packageJson from '../../../package.json';
+import nls from '../../../package.nls.json';
+import nlsTemplate from '../../../package.nls.template.json';
 
 describe('I18n: tests', function () {
 

--- a/test/iconGenerator/functionality.test.ts
+++ b/test/iconGenerator/functionality.test.ts
@@ -1,14 +1,14 @@
 // tslint:disable only-arrow-functions
 // tslint:disable no-unused-expression
+import fs from 'fs';
+import sinon from 'sinon';
+import packageJson from '../../../package.json';
 import { expect } from 'chai';
-import * as fs from 'fs';
-import * as sinon from 'sinon';
 import { schema as defaultSchema, IconGenerator } from '../../src/icon-manifest';
 import { IFileCollection, IFolderCollection } from '../../src/models';
 import * as utils from '../../src/utils';
 import { extensionSettings as settings } from '../../src/settings';
 import { extensions as folderExtensions } from '../support/supportedFolders';
-import * as packageJson from '../../../package.json';
 
 describe('IconGenerator: functionality test', function () {
 

--- a/test/iconGenerator/iconGeneration-files.test.ts
+++ b/test/iconGenerator/iconGeneration-files.test.ts
@@ -1,6 +1,6 @@
 // tslint:disable only-arrow-functions
-import * as fs from 'fs';
-import * as path from 'path';
+import fs from 'fs';
+import path from 'path';
 import { expect } from 'chai';
 import { schema as defaultSchema, IconGenerator } from '../../src/icon-manifest';
 import { extensions as files } from '../../src/icon-manifest/supportedExtensions';

--- a/test/iconGenerator/iconGeneration-folders.test.ts
+++ b/test/iconGenerator/iconGeneration-folders.test.ts
@@ -1,6 +1,6 @@
 // tslint:disable only-arrow-functions
-import * as fs from 'fs';
-import * as path from 'path';
+import fs from 'fs';
+import path from 'path';
 import { expect } from 'chai';
 import { schema as defaultSchema, IconGenerator } from '../../src/icon-manifest';
 import { extensions as folders } from '../../src/icon-manifest/supportedFolders';

--- a/test/init/applyCustomizationsManager.test.ts
+++ b/test/init/applyCustomizationsManager.test.ts
@@ -1,7 +1,7 @@
 // tslint:disable only-arrow-functions
 // tslint:disable no-unused-expression
+import sinon from 'sinon';
 import { expect } from 'chai';
-import * as sinon from 'sinon';
 import { manageAutoApplyCustomizations, manageApplyCustomizations } from '../../src/init/applyCustomizationsManager';
 import { IVSIcons } from '../../src/models';
 

--- a/test/init/projectAutoDetection.test.ts
+++ b/test/init/projectAutoDetection.test.ts
@@ -1,8 +1,8 @@
 // tslint:disable only-arrow-functions
 // tslint:disable no-unused-expression
+import fs from 'fs';
+import sinon from 'sinon';
 import { expect } from 'chai';
-import * as fs from 'fs';
-import * as sinon from 'sinon';
 import * as models from '../../src/models';
 import { ProjectAutoDetection as pad } from '../../src/init/projectAutoDetection';
 import { ManifestReader as mr } from '../../src/icon-manifest';

--- a/test/manifestMerger/defaultExtensions.test.ts
+++ b/test/manifestMerger/defaultExtensions.test.ts
@@ -1,7 +1,7 @@
 // tslint:disable only-arrow-functions
 // tslint:disable no-unused-expression
-import * as fs from 'fs';
-import * as path from 'path';
+import fs from 'fs';
+import path from 'path';
 import { expect } from 'chai';
 import { extensions as fileExtensions } from '../support/supportedExtensions';
 import { extensions as folderExtensions } from '../support/supportedFolders';

--- a/test/manifestMerger/fileExtensions.test.ts
+++ b/test/manifestMerger/fileExtensions.test.ts
@@ -1,7 +1,7 @@
 // tslint:disable only-arrow-functions
 // tslint:disable no-unused-expression
-import * as fs from 'fs';
-import * as path from 'path';
+import fs from 'fs';
+import path from 'path';
 import { expect } from 'chai';
 import { extensions as fileExtensions } from '../support/supportedExtensions';
 import { extensions as folderExtensions } from '../support/supportedFolders';

--- a/test/manifestMerger/folderExtensions.test.ts
+++ b/test/manifestMerger/folderExtensions.test.ts
@@ -1,7 +1,7 @@
 // tslint:disable only-arrow-functions
 // tslint:disable no-unused-expression
-import * as fs from 'fs';
-import * as path from 'path';
+import fs from 'fs';
+import path from 'path';
 import { expect } from 'chai';
 import { extensions as fileExtensions } from '../support/supportedExtensions';
 import { extensions as folderExtensions } from '../support/supportedFolders';

--- a/test/settings/settings.test.ts
+++ b/test/settings/settings.test.ts
@@ -1,8 +1,8 @@
 // tslint:disable only-arrow-functions
 // tslint:disable no-unused-expression
+import fs from 'fs';
+import sinon from 'sinon';
 import { expect } from 'chai';
-import * as fs from 'fs';
-import * as sinon from 'sinon';
 import { vscode } from '../../src/utils';
 import { extensionSettings, SettingsManager } from '../../src/settings';
 import { ExtensionStatus, IState } from '../../src/models';

--- a/test/utils/utils.test.ts
+++ b/test/utils/utils.test.ts
@@ -1,9 +1,9 @@
 // tslint:disable only-arrow-functions
 // tslint:disable no-unused-expression
+import fs from 'fs';
+import os from 'os';
+import sinon from 'sinon';
 import { expect } from 'chai';
-import * as fs from 'fs';
-import * as os from 'os';
-import * as sinon from 'sinon';
 import * as utils from '../../src/utils';
 
 describe('Utils: tests', function () {

--- a/test/utils/vscode-extensions.test.ts
+++ b/test/utils/vscode-extensions.test.ts
@@ -1,7 +1,7 @@
 // tslint:disable only-arrow-functions
 // tslint:disable no-unused-expression
+import mockery from 'mockery';
 import { expect } from 'chai';
-import * as mockery from 'mockery';
 
 describe('vscode-extensions: tests', function () {
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,7 @@
     "moduleResolution": "node",
     "noUnusedLocals": true,
     "noUnusedParameters": true,
+    "esModuleInterop": true,
     "skipLibCheck": true,
     "target": "es6",
     "outDir": "out",


### PR DESCRIPTION
As per:
- https://blogs.msdn.microsoft.com/typescript/2018/01/31/announcing-typescript-2-7/#easier-ecmascript-module-interoperability
- https://github.com/Microsoft/TypeScript/issues/21535
- https://github.com/Microsoft/TypeScript/wiki/What's-new-in-TypeScript#support-for-import-d-from-cjs-form-commonjs-modules-with---esmoduleinterop