### PR TITLE
Add publish stage in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,14 @@ jobs:
       script: npm run compile
       after_success: wpilgen
 
+    - stage: publish
+      if: repo =~ ^vscode-icons AND tag IS present AND type = push
+      os: linux
+      node_js: 7.9.0
+      before_script: npm i vsce --no-save
+      script: npm run build
+      after_success: vsce publish -p $VSCE_TOKEN
+
     - stage: docker vsi:latest
       if: repo =~ ^vscode-icons AND branch = master AND type = push
       sudo: required

--- a/src/settings/extensionSettings.ts
+++ b/src/settings/extensionSettings.ts
@@ -1,7 +1,8 @@
 import { IExtensionSettings } from '../models';
+import * as manifest from '../../../package.json';
 
 export const extensionSettings: IExtensionSettings = {
-  version: '7.23.0',
+  version: manifest.version,
   iconJsonFileName: 'icons.json',
   iconSuffix: '',
   filePrefix: 'file_type_',


### PR DESCRIPTION
This PR automates the publication process.

Steps:
- The member constructs the `CHANGELOG`.
- The member performs locally `npm version <version> --no-git-tag-version`.
- The member submits the PR for approval.
- Upon approval from another member, the member merges the PR.
- The member pulls the latest commit locally.
- The member tags the merged commit.
- The member pushes the tag.
- `CI` picks up the tag and does the publication.

**Note:** 
- `member` is a member of the @vscode-icons/development team.

Requirements:
@robertohuertasm In order for this to work a secure environment variable MUST be set in `travis` settings, named `VSCE_TOKEN` with a value of the `vsce` publisher token. It's recommended to generate a fresh token, so it lasts longer, as they have a max year long lifetime.

Additionally, the `extensionSettings` version has been automated. It will always point to the manifest (`package.json`) version.