### PR TITLE
support more rollup variations

### DIFF
--- a/src/icon-manifest/supportedExtensions.ts
+++ b/src/icon-manifest/supportedExtensions.ts
@@ -2276,7 +2276,14 @@ export const extensions: IFileCollection = {
     },
     {
       icon: 'rollup',
-      extensions: ['rollup.config.js', 'rollup.config.ts'],
+      extensions: [],
+      filenamesGlob: [
+        'rollup.config',
+        'rollup.config.common',
+        'rollup.config.dev',
+        'rollup.config.prod'
+      ],
+      extensionsGlob: ['js', 'coffee', 'ts'],
       filename: true,
       format: FileFormat.svg,
     },


### PR DESCRIPTION
Support `rollup.config.common`,`rollup.config.dev` and `rollup.config.prod` variations. 

Resolve #1704.

<img width="260" alt="qq20180902-202516 2x" src="https://user-images.githubusercontent.com/3783096/44955935-52d5e880-aeee-11e8-8655-80d118749dc1.png">


