### PR TITLE
Fix Jenkins default extension

### DIFF
--- a/src/iconsManifest/languages.ts
+++ b/src/iconsManifest/languages.ts
@@ -95,7 +95,7 @@ export const languages: ILanguageCollection = {
   javascript: { ids: 'javascript', defaultExtension: 'js' },
   javascriptreact: { ids: 'javascriptreact', defaultExtension: 'jsx' },
   jekyll: { ids: 'jekyll', defaultExtension: 'jekyll' },
-  jenkins: { ids: ['jenkins', 'declarative'], defaultExtension: 'jenkins' },
+  jenkins: { ids: ['jenkins', 'declarative'], defaultExtension: 'jenkinsfile' },
   jinja: { ids: 'jinja', defaultExtension: 'jinja' },
   json: { ids: 'json', defaultExtension: 'json' },
   jsonc: { ids: 'jsonc', defaultExtension: 'jsonc' },


### PR DESCRIPTION
Change this to Jenkinsfile.
This is the default extension for Jenkins multibranch pipelines.
see:
https://jenkins.io/doc/book/pipeline/jenkinsfile/

<!-- markdownlint-disable MD041-->

<!-- Please first read how to submit a pull request, if you haven't already done so.
https://github.com/vscode-icons/vscode-icons/wiki/PullRequest -->

**Changes proposed:**

- [ ] Add
- [ ] Delete
- [x] Fix
- [ ] Prepare
