### PR TITLE
Add default formater in settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -11,5 +11,11 @@
     "examples": true
   },
   "typescript.tsdk": "./node_modules/typescript/lib",
+  "[typescript]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[jsonc]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
   "vsicons.projectDetection.disableDetect": true
 }


### PR DESCRIPTION
Since we use `Prettier` adding those to `settings` will stop `vscode` asking to choose.
