### PR TITLE
support for widgets folder (flutter)

### DIFF
--- a/src/iconsManifest/supportedFolders.ts
+++ b/src/iconsManifest/supportedFolders.ts
@@ -68,7 +68,7 @@ export const extensions: IFolderCollection = {
     },
     {
       icon: 'component',
-      extensions: ['components', '.components'],
+      extensions: ['components', '.components', 'widgets'],
       format: FileFormat.svg,
     },
     {


### PR DESCRIPTION
**Changes proposed:**
- [x] Add

Although there's no established convention yet it seems that many people are using `widgets` as normally you would use `components` in many other frameworks.  Indeed, one could argue that in the Flutter lingo widgets are components.

See [this](https://hackernoon.com/scalable-app-structure-in-flutter-dad61a4bc389)

