### PR TITLE
Haxelib icon should only be used for .haxelib

### DIFF
--- a/src/iconsManifest/supportedFolders.ts
+++ b/src/iconsManifest/supportedFolders.ts
@@ -180,7 +180,7 @@ export const extensions: IFolderCollection = {
       ],
       format: FileFormat.svg,
     },
-    { icon: 'haxelib', extensions: ['haxelib'], format: FileFormat.svg },
+    { icon: 'haxelib', extensions: ['.haxelib', 'haxe_libraries'], format: FileFormat.svg },
     {
       icon: 'helper',
       extensions: ['helpers', '.helpers'],


### PR DESCRIPTION
\+ add haxe_libraries (used by a Haxe package manager called lix)


