### PR TITLE
Improve support for Sequelize

### DIFF
--- a/src/iconsManifest/supportedExtensions.ts
+++ b/src/iconsManifest/supportedExtensions.ts
@@ -3023,7 +3023,7 @@ export const extensions: IFileCollection = {
     },
     {
       icon: 'sequelize',
-      extensions: ['.sequelizerc'],
+      extensions: ['.sequelizerc', '.sequelizerc.js', '.sequelizerc.json'],
       filename: true,
       format: FileFormat.svg,
     },

--- a/src/iconsManifest/supportedExtensions.ts
+++ b/src/iconsManifest/supportedExtensions.ts
@@ -3023,7 +3023,9 @@ export const extensions: IFileCollection = {
     },
     {
       icon: 'sequelize',
-      extensions: ['.sequelizerc', '.sequelizerc.js', '.sequelizerc.json'],
+      extensions: ['.sequelizerc'],
+      filenamesGlob: ['.sequelizerc'],
+      extensionsGlob: ['js', 'json'],
       filename: true,
       format: FileFormat.svg,
     },


### PR DESCRIPTION
Improve support for [Sequelize](https://github.com/sequelize/sequelize). Currently only  `.sequelizerc` is supported, but `.sequelizerc.js` and `.sequelizerc.json` should also be supported.

**Changes proposed:**

- [X] Add