### PR TITLE
Fix the minimum supported editor version

### DIFF
--- a/src/vscode/vscodeManager.ts
+++ b/src/vscode/vscodeManager.ts
@@ -1,11 +1,10 @@
+import { coerce, gte, parse } from 'semver';
+import * as manifest from '../../../package.json';
 import * as models from '../models';
 import { Utils } from '../utils';
-import { gte } from 'semver';
-import * as manifest from '../../../package.json';
 
 export class VSCodeManager implements models.IVSCodeManager {
   private appUserDirPath: string;
-  private supportedVersion: string = '1.28.1';
   private supportsThemeReloadVersion: string = '1.34.0';
 
   constructor(
@@ -53,7 +52,11 @@ export class VSCodeManager implements models.IVSCodeManager {
   }
 
   public get isSupportedVersion(): boolean {
-    return gte(this.version, this.supportedVersion);
+    const minVersion = (
+      (manifest && manifest.engines && coerce(manifest.engines.vscode)) ||
+      parse('1.0.0')
+    ).version;
+    return gte(this.version, minVersion);
   }
 
   public getWorkspacePaths(): string[] {

--- a/test/vscode/vscodeManager.test.ts
+++ b/test/vscode/vscodeManager.test.ts
@@ -2,11 +2,12 @@
 // tslint:disable no-unused-expression
 import { expect } from 'chai';
 import * as sinon from 'sinon';
-import { VSCodeManager } from '../../src/vscode/vscodeManager';
+import * as manifest from '../../../package.json';
 import { IVSCodeManager } from '../../src/models';
 import { Utils } from '../../src/utils';
-import { vscode } from '../fixtures/vscode';
+import { VSCodeManager } from '../../src/vscode/vscodeManager';
 import { context as extensionContext } from '../fixtures/extensionContext';
+import { vscode } from '../fixtures/vscode';
 
 describe('VSCodeManager: tests', function () {
   context('ensures that', function () {
@@ -87,14 +88,45 @@ describe('VSCodeManager: tests', function () {
       context(`when editor version`, function () {
         context(`is NOT supported`, function () {
           it(`returns 'false'`, function () {
-            vscode.version = '1.28.0';
+            vscode.version = '1.26.0';
 
             expect(vscodeManager.isSupportedVersion).to.be.false;
           });
+        });
 
-          context(`is supported`, function () {
+        context(`is supported`, function () {
+          it(`returns 'true'`, function () {
+            vscode.version = '1.34.0';
+
+            expect(vscodeManager.isSupportedVersion).to.be.true;
+          });
+        });
+      });
+
+      context(`when minimum supported version`, function () {
+        context(`can NOT be determined`, function () {
+          let manifestVSCodeEngineOriginalValue: string;
+
+          beforeEach(function () {
+            manifestVSCodeEngineOriginalValue = manifest.engines.vscode;
+            vscode.version = '1.26.0';
+          });
+
+          afterEach(function () {
+            manifest.engines = { vscode };
+            manifest.engines.vscode = manifestVSCodeEngineOriginalValue;
+          });
+
+          context(`by the 'vscode' property`, function () {
             it(`returns 'true'`, function () {
-              vscode.version = '1.34.0';
+              manifest.engines.vscode = undefined;
+
+              expect(vscodeManager.isSupportedVersion).to.be.true;
+            });
+          });
+          context(`by the 'engines' property`, function () {
+            it(`returns 'true'`, function () {
+              manifest.engines = undefined;
 
               expect(vscodeManager.isSupportedVersion).to.be.true;
             });


### PR DESCRIPTION
<!-- markdownlint-disable MD041-->

<!-- Please first read how to submit a pull request, if you haven't already done so.
https://github.com/vscode-icons/vscode-icons/wiki/PullRequest -->

_**Fixes #2218**_

**Changes proposed:**

- [x] Fix

We now rely on the `vscode` version, set in `engines` property of the `package.json` manifest to determine the minimum supported `vscode` version.
