### PR TITLE
Pixel perfect default file icon

### DIFF
--- a/icons/default_file.svg
+++ b/icons/default_file.svg
@@ -1,1 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32"><title>default_file</title><path d="M20.75,2H4.35V30h23.3V9Zm4.6,25.7H6.75V4.3h11.7v7h7V27.7Z" style="fill:#c5c5c5"/></svg>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32"><title>default_file</title><path d="M20.414,2H5V30H27V8.586ZM7,28V4H19v6h6V28Z" style="fill:#c5c5c5"/></svg>


### PR DESCRIPTION
<!-- markdownlint-disable MD041-->

<!-- Please first read how to submit a pull request, if you haven't already done so.
https://github.com/vscode-icons/vscode-icons/wiki/PullRequest -->

**Changes proposed:**

- [ ] Add
- [ ] Delete
- [x] Fix
- [ ] Prepare

The default file icon wasn't pixel perfect, this PR address that. In the future, I do feel like some icons can be made pixel perfect due to its design simplicity.