### PR TITLE
README.md: abbreviate "installs" badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # vscode-icons
 
 [![Version](https://vsmarketplacebadge.apphb.com/version/vscode-icons-team.vscode-icons.svg)](https://marketplace.visualstudio.com/items?itemName=vscode-icons-team.vscode-icons)
-[![Installs](https://vsmarketplacebadge.apphb.com/installs/vscode-icons-team.vscode-icons.svg)](https://marketplace.visualstudio.com/items?itemName=vscode-icons-team.vscode-icons)
+[![Installs](https://vsmarketplacebadge.apphb.com/installs-short/vscode-icons-team.vscode-icons.svg)](https://marketplace.visualstudio.com/items?itemName=vscode-icons-team.vscode-icons)
 [![Ratings](https://vsmarketplacebadge.apphb.com/rating/vscode-icons-team.vscode-icons.svg)](https://marketplace.visualstudio.com/items?itemName=vscode-icons-team.vscode-icons)
 
 [![Build Status](https://travis-ci.org/vscode-icons/vscode-icons.svg?branch=master)](https://travis-ci.org/vscode-icons/vscode-icons)


### PR DESCRIPTION
<!-- markdownlint-disable MD041-->

<!-- Please first read how to submit a pull request, if you haven't already done so.
https://github.com/vscode-icons/vscode-icons/wiki/PullRequest -->


Kind of random, but saw this on the README and wanted to fix it.
"3644194 installs" is hard to parse; abbreviate to "3.64M installs".

### Before

![image](https://user-images.githubusercontent.com/3344958/65395252-43ba1680-dd4d-11e9-8d39-4f9ddd3dc759.png)


### After
![image](https://user-images.githubusercontent.com/3344958/65395254-4583da00-dd4d-11e9-99ff-9018300aa266.png)