### PR TITLE
Add support for Cloud Foundry Manifest Language

### DIFF
--- a/src/iconsManifest/languages.ts
+++ b/src/iconsManifest/languages.ts
@@ -43,6 +43,7 @@ export const languages: ILanguageCollection = {
   cfm: { ids: 'cfmhtml', defaultExtension: 'cfm' },
   clojure: { ids: 'clojure', defaultExtension: 'clojure' },
   clojurescript: { ids: 'clojurescript', defaultExtension: 'clojurescript' },
+  cloudfoundrymanifest: { ids: 'manifest-yaml', defaultExtension: 'yml' },
   cmake: { ids: 'cmake', defaultExtension: 'cmake' },
   cmakecache: { ids: 'cmake-cache', defaultExtension: 'CMakeCache.txt' },
   cobol: { ids: 'cobol', defaultExtension: 'cbl' },

--- a/src/iconsManifest/supportedExtensions.ts
+++ b/src/iconsManifest/supportedExtensions.ts
@@ -871,6 +871,7 @@ export const extensions: IFileCollection = {
       extensions: ['.cfignore'],
       light: true,
       filename: true,
+      languages: [languages.cloudfoundrymanifest],
       format: FileFormat.svg,
     },
     {

--- a/src/models/language/languageCollection.ts
+++ b/src/models/language/languageCollection.ts
@@ -36,6 +36,7 @@ export interface ILanguageCollection extends INativeLanguageCollection {
   caddyfile: ILanguage;
   cfc: ILanguage;
   cfm: ILanguage;
+  cloudfoundrymanifest: ILanguage;
   cmake: ILanguage;
   cmakecache: ILanguage;
   cobol: ILanguage;


### PR DESCRIPTION
<!-- markdownlint-disable MD041-->

<!-- Please first read how to submit a pull request, if you haven't already done so.
https://github.com/vscode-icons/vscode-icons/wiki/PullRequest -->

_**Fixes #2339**_

**Changes proposed:**

- [x] Add support for Cloud Foundry Manifest Language using existing `cloudfoundry` icon
