### PR TITLE
Add kitchen.yml as a Test Kitchen file

### DIFF
--- a/src/iconsManifest/supportedExtensions.ts
+++ b/src/iconsManifest/supportedExtensions.ts
@@ -1987,7 +1987,10 @@ export const extensions: IFileCollection = {
     },
     {
       icon: 'kitchenci',
-      extensions: ['.kitchen.yml'],
+      extensions: [
+        '.kitchen.yml',
+        'kitchen.yml',
+      ],
       filename: true,
       format: FileFormat.svg,
     },


### PR DESCRIPTION
The default config for Test Kitchen is no longer .kitchen.yml. We changed it to kitchen.yml about a year ago and those aren't picked up by this extension.

_**Fixes #IssueNumber**_

None

**Changes proposed:**

- [ ] Add
- [ ] Delete
- [x] Fix
- [ ] Prepare
