### PR TITLE
Fix 'tox' file association

### DIFF
--- a/src/iconsManifest/supportedExtensions.ts
+++ b/src/iconsManifest/supportedExtensions.ts
@@ -3571,8 +3571,7 @@ export const extensions: IFileCollection = {
     },
     {
       icon: 'tox',
-      extensions: ['.ini'],
-      filenamesGlob: ['tox.ini'],
+      extensions: ['tox.ini'],
       filename: true,
       format: FileFormat.svg,
     },


### PR DESCRIPTION
Unfortunately bad association slipt through for `tox`. This fixes it.