### PR TITLE
fix(travis): fix travis nodejs version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ jobs:
     - stage: wiki pages icons list update
       if: repo =~ ^vscode-icons AND branch = master AND type = push
       os: linux
-      node_js: 8.9.3
+      node_js: 10.2.0
       addons:
         apt:
           sources: [ubuntu-toolchain-r-test]


### PR DESCRIPTION
Publish hasn't worked, I'm not sure why, but a quick look at the travis file shows that wiki pages were still using the former version of node.

