### PR TITLE
Remove tslint dependency

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,9 +1,0 @@
-node_modules
-submodules
-dist
-out
-coverage
-/.*
-/*.*
-.*
-*.d.ts

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -11,6 +11,17 @@
     "prettier/@typescript-eslint"
     // "plugin:prettier/recommended" // Note: Enable when Prettier v2.0 gets released
   ],
+  "ignorePatterns": [
+    "node_modules",
+    "submodules",
+    "dist",
+    "out",
+    "coverage",
+    "/.*",
+    "/*.*",
+    ".*",
+    "*.d.ts"
+  ],
   "parser": "@typescript-eslint/parser",
   "parserOptions": {
     "project": "tsconfig.json",

--- a/greenkeeper.json
+++ b/greenkeeper.json
@@ -1,7 +1,6 @@
 {
   "ignore": [
     "@types/node",
-    "@types/vscode",
-    "tslint"
+    "@types/vscode"
   ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -421,16 +421,6 @@
         "tsutils": "^3.17.1"
       }
     },
-    "@typescript-eslint/eslint-plugin-tslint": {
-      "version": "2.19.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin-tslint/-/eslint-plugin-tslint-2.19.2.tgz",
-      "integrity": "sha512-S6F+Iaq3WIZN1aj6ar9Obda6kF3UaRWzT1Phi/CGp0mrSuaO1g8G+VJ0QG2HJ7S7CIKXMy7zXmF2alZ38EIVzw==",
-      "dev": true,
-      "requires": {
-        "@typescript-eslint/experimental-utils": "2.19.2",
-        "lodash": "^4.17.15"
-      }
-    },
     "@typescript-eslint/experimental-utils": {
       "version": "2.19.2",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-2.19.2.tgz",
@@ -1133,12 +1123,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
       "integrity": "sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk=",
-      "dev": true
-    },
-    "builtin-modules": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
-      "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
       "dev": true
     },
     "builtin-status-codes": {
@@ -7020,56 +7004,6 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
       "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==",
       "dev": true
-    },
-    "tslint": {
-      "version": "5.20.1",
-      "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.20.1.tgz",
-      "integrity": "sha512-EcMxhzCFt8k+/UP5r8waCf/lzmeSyVlqxqMEDQE7rWYiQky8KpIBz1JAoYXfROHrPZ1XXd43q8yQnULOLiBRQg==",
-      "dev": true,
-      "requires": {
-        "@babel/code-frame": "^7.0.0",
-        "builtin-modules": "^1.1.1",
-        "chalk": "^2.3.0",
-        "commander": "^2.12.1",
-        "diff": "^4.0.1",
-        "glob": "^7.1.1",
-        "js-yaml": "^3.13.1",
-        "minimatch": "^3.0.4",
-        "mkdirp": "^0.5.1",
-        "resolve": "^1.3.2",
-        "semver": "^5.3.0",
-        "tslib": "^1.8.0",
-        "tsutils": "^2.29.0"
-      },
-      "dependencies": {
-        "commander": {
-          "version": "2.20.3",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-          "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-          "dev": true
-        },
-        "diff": {
-          "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-          "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
-          "dev": true
-        },
-        "semver": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-          "dev": true
-        },
-        "tsutils": {
-          "version": "2.29.0",
-          "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.29.0.tgz",
-          "integrity": "sha512-g5JVHCIJwzfISaXpXE1qvNalca5Jwob6FjI4AoPlqMusJ6ftFE7IkkFoMhVLRgK+4Kx3gkzb8UZK5t5yTTvEmA==",
-          "dev": true,
-          "requires": {
-            "tslib": "^1.8.1"
-          }
-        }
-      }
     },
     "tsutils": {
       "version": "3.17.1",

--- a/package.json
+++ b/package.json
@@ -299,7 +299,6 @@
     "@types/vscode": "1.31",
     "@types/webpack": "^4.41.6",
     "@typescript-eslint/eslint-plugin": "^2.19.2",
-    "@typescript-eslint/eslint-plugin-tslint": "^2.19.2",
     "@typescript-eslint/parser": "^2.19.2",
     "chai": "^4.2.0",
     "eslint": "^6.8.0",
@@ -317,7 +316,6 @@
     "rimraf": "^3.0.2",
     "sinon": "^8.1.1",
     "ts-node": "^8.6.2",
-    "tslint": "5.20.1",
     "typescript": "^3.7.5",
     "webpack": "^4.41.6",
     "webpack-cli": "^3.3.11"


### PR DESCRIPTION
Having now a better understanding of `eslint` we can totally remove `tslint` dependency.

`tslint` is only required when `@typescript-eslint/eslint-plugin-tslint` is used, in order to load `tslint` rules specified in `.eslintrc.json` (those that are transferred from the `tslint.json` file when migrating). Since we don't use any rules from `tslint.json` anymore there is no reason to include those dependencies.