### PR TITLE
Renovate / Add support for renovate.config.js

### DIFF
--- a/src/iconsManifest/supportedExtensions.ts
+++ b/src/iconsManifest/supportedExtensions.ts
@@ -3147,7 +3147,7 @@ export const extensions: IFileCollection = {
     },
     {
       icon: 'renovate',
-      extensions: ['.renovaterc'],
+      extensions: ['.renovaterc', 'renovate.js', 'renovate.config.js'],
       filenamesGlob: ['renovate', '.renovaterc'],
       extensionsGlob: ['json'],
       filename: true,


### PR DESCRIPTION
As the preferred way for using Renovate with their official Github Action is to use a `.js` file instead of a `json`, we should add `renovate.js` and `renovate.config.js`.

<!-- markdownlint-disable MD041-->

**Changes proposed:**

- [x] Add
