### PR TITLE
Extend husky icon to support husky.config.js

### DIFF
--- a/src/iconsManifest/supportedExtensions.ts
+++ b/src/iconsManifest/supportedExtensions.ts
@@ -1751,7 +1751,7 @@ export const extensions: IFileCollection = {
     },
     {
       icon: 'husky',
-      extensions: ['.huskyrc'],
+      extensions: ['.huskyrc', 'husky.config.js'],
       filenamesGlob: ['.huskyrc'],
       extensionsGlob: ['js', 'json', 'yaml', 'yml'],
       filename: true,


### PR DESCRIPTION
**Changes proposed:**

- [x] Add
- [x] Fix

> Starting with 1.0.0, husky can be configured using `.huskyrc`, `.huskyrc.json`, `.huskyrc.yaml`, `huskyrc.yml`, `.huskyrc.js` or `husky.config.js` file.

_Ref: https://github.com/typicode/husky#upgrading-from-014_