### PR TITLE
Add conf to options for Config folder

### DIFF
--- a/src/iconsManifest/supportedFolders.ts
+++ b/src/iconsManifest/supportedFolders.ts
@@ -100,6 +100,10 @@ export const extensions: IFolderCollection = {
     {
       icon: 'config',
       extensions: [
+        'conf',
+        '.conf',
+        'configs',
+        '.configs',
         'config',
         '.config',
         'configs',

--- a/src/iconsManifest/supportedFolders.ts
+++ b/src/iconsManifest/supportedFolders.ts
@@ -102,8 +102,6 @@ export const extensions: IFolderCollection = {
       extensions: [
         'conf',
         '.conf',
-        'configs',
-        '.configs',
         'config',
         '.config',
         'configs',


### PR DESCRIPTION
For Java/Scala Play framework projects they have a conf folder. Ideally, this would show the same icon as the config folder currently it just shows the default icon.

**Changes proposed:**

- [ ] Add
- [ ] Delete
- [x] Fix
- [ ] Prepare
