### PR TITLE
feat: support tool folder within the tools category

### DIFF
--- a/src/iconsManifest/supportedFolders.ts
+++ b/src/iconsManifest/supportedFolders.ts
@@ -534,7 +534,7 @@ export const extensions: IFolderCollection = {
     { icon: 'travis', extensions: ['.travis'], format: FileFormat.svg },
     {
       icon: 'tools',
-      extensions: ['tools', '.tools', 'util', 'utils'],
+      extensions: ['tool', 'tools', '.tools', 'util', 'utils'],
       format: FileFormat.svg,
     },
     {


### PR DESCRIPTION
<!-- markdownlint-disable MD041-->

<!-- Please first read how to submit a pull request, if you haven't already done so.
https://github.com/vscode-icons/vscode-icons/wiki/PullRequest -->

_**Fixes #2583**_

**Changes proposed:**

- [x] Add
- [ ] Delete
- [ ] Fix
- [ ] Prepare

In Dart, it is a convention to use a `tool` folder: https://dart.dev/tools/pub/package-layout#internal-tools-and-scripts

This PR adds support for it within the same `tools` category.
