### PR TITLE
add .bazel extension support for Bazel

### DIFF
--- a/src/iconsManifest/languages.ts
+++ b/src/iconsManifest/languages.ts
@@ -252,6 +252,7 @@ export const languages: ILanguageCollection = {
   sql: { ids: 'sql', defaultExtension: 'sql' },
   squirrel: { ids: 'squirrel', defaultExtension: 'nut' },
   stan: { ids: 'stan', defaultExtension: 'stan' },
+  starlark: { ids: 'starlark', defaultExtension: 'bazel' },
   stata: { ids: 'stata', defaultExtension: 'do' },
   stencil: { ids: 'stencil', defaultExtension: 'stencil' },
   stencilhtml: { ids: 'stencil-html', defaultExtension: 'html.stencil' },

--- a/src/iconsManifest/supportedExtensions.ts
+++ b/src/iconsManifest/supportedExtensions.ts
@@ -629,7 +629,7 @@ export const extensions: IFileCollection = {
     },
     {
       icon: 'bazel',
-      extensions: ['.bazelrc', 'bazel.rc', 'bazel.bazelrc'],
+      extensions: ['.bazel', '.bazelrc', 'bazel.rc', 'bazel.bazelrc'],
       filename: true,
       languages: [languages.bazel],
       format: FileFormat.svg,

--- a/src/iconsManifest/supportedExtensions.ts
+++ b/src/iconsManifest/supportedExtensions.ts
@@ -629,7 +629,7 @@ export const extensions: IFileCollection = {
     },
     {
       icon: 'bazel',
-      extensions: ['.bazel', '.bazelrc', 'bazel.rc', 'bazel.bazelrc'],
+      extensions: ['BUILD.bazel', '.bazelrc', 'bazel.rc', 'bazel.bazelrc'],
       filename: true,
       languages: [languages.bazel],
       format: FileFormat.svg,

--- a/src/iconsManifest/supportedExtensions.ts
+++ b/src/iconsManifest/supportedExtensions.ts
@@ -631,7 +631,7 @@ export const extensions: IFileCollection = {
       icon: 'bazel',
       extensions: ['BUILD.bazel', '.bazelrc', 'bazel.rc', 'bazel.bazelrc'],
       filename: true,
-      languages: [languages.bazel],
+      languages: [languages.bazel, languages.starlark],
       format: FileFormat.svg,
     },
     {

--- a/src/models/language/languageCollection.ts
+++ b/src/models/language/languageCollection.ts
@@ -194,6 +194,7 @@ export interface ILanguageCollection extends INativeLanguageCollection {
   sqf: ILanguage;
   squirrel: ILanguage;
   stan: ILanguage;
+  starlark: ILanguage;
   stata: ILanguage;
   stencil: ILanguage;
   stencilhtml: ILanguage;


### PR DESCRIPTION
e.g. [googletest](https://github.com/google/googletest/blob/master/BUILD.bazel) uses the .bazel extension and [many other projects](https://github.com/search?l=&q=extension%3Abazel+load&type=Code) seem to do so as well.

**TODO:**
- [x] fix filename
- [x] add `starlark` language support

<!-- markdownlint-disable MD041-->

**Changes proposed:**

- [x] Add
