### PR TITLE
Add COPYING filename associations to license icon

### DIFF
--- a/src/iconsManifest/supportedExtensions.ts
+++ b/src/iconsManifest/supportedExtensions.ts
@@ -2188,8 +2188,8 @@ export const extensions: IFileCollection = {
     { icon: 'license', extensions: ['enc'], format: FileFormat.svg },
     {
       icon: 'license',
-      extensions: ['license', 'licence', 'copying'],
-      filenamesGlob: ['license', 'licence', 'copying'],
+      extensions: ['license', 'licence', 'copying', 'copying.lesser'],
+      filenamesGlob: ['license', 'licence', 'copying', 'copying.lesser'],
       extensionsGlob: ['md', 'txt'],
       filename: true,
       format: FileFormat.svg,

--- a/src/iconsManifest/supportedExtensions.ts
+++ b/src/iconsManifest/supportedExtensions.ts
@@ -2188,8 +2188,8 @@ export const extensions: IFileCollection = {
     { icon: 'license', extensions: ['enc'], format: FileFormat.svg },
     {
       icon: 'license',
-      extensions: ['license', 'licence'],
-      filenamesGlob: ['license', 'licence'],
+      extensions: ['license', 'licence', 'copying'],
+      filenamesGlob: ['license', 'licence', 'copying'],
       extensionsGlob: ['md', 'txt'],
       filename: true,
       format: FileFormat.svg,


### PR DESCRIPTION
<!-- markdownlint-disable MD041-->

<!-- Please first read how to submit a pull request, if you haven't already done so.
https://github.com/vscode-icons/vscode-icons/wiki/PullRequest -->

**Changes proposed:**

- [x] Add

Thought it'd be nice to add `COPYING`, `COPYING.md`, and `COPYING.txt` filename associations to the [license](https://github.com/vscode-icons/vscode-icons/wiki/ListOfFiles/3fef37e26bb944b5303c1dbc813859f48c31e416#license) icon [for the GNU crowd](https://www.gnu.org/licenses/gpl-howto.html). And `COPYING.LESSER`, which I've just learned is the filename they recommend for the LGPL.