### PR TITLE
Make MDX a code language

### DIFF
--- a/src/iconsManifest/languages.ts
+++ b/src/iconsManifest/languages.ts
@@ -161,6 +161,7 @@ export const languages: ILanguageCollection = {
   marko: { ids: 'marko', defaultExtension: 'marko' },
   matlab: { ids: 'matlab', defaultExtension: 'mat' },
   maxscript: { ids: 'maxscript', defaultExtension: 'ms' },
+  mdx: { ids: 'mdx', defaultExtension: 'mdx' },
   mediawiki: { ids: 'mediawiki', defaultExtension: 'mediawiki' },
   mel: { ids: 'mel', defaultExtension: 'mel' },
   meson: { ids: 'meson', defaultExtension: 'meson.build' },

--- a/src/iconsManifest/supportedExtensions.ts
+++ b/src/iconsManifest/supportedExtensions.ts
@@ -2333,7 +2333,8 @@ export const extensions: IFileCollection = {
     },
     {
       icon: 'mdx',
-      extensions: ['mdx'],
+      extensions: [],
+      languages: [languages.mdx],
       light: true,
       format: FileFormat.svg,
     },

--- a/src/models/language/languageCollection.ts
+++ b/src/models/language/languageCollection.ts
@@ -128,6 +128,7 @@ export interface ILanguageCollection extends INativeLanguageCollection {
   marko: ILanguage;
   matlab: ILanguage;
   maxscript: ILanguage;
+  mdx: ILanguage;
   mediawiki: ILanguage;
   mel: ILanguage;
   meson: ILanguage;


### PR DESCRIPTION
<!-- markdownlint-disable MD041-->

<!-- Please first read how to submit a pull request, if you haven't already done so.
https://github.com/vscode-icons/vscode-icons/wiki/PullRequest -->

#### Changes proposed:

- [x] Add
- [x] Delete

Adds [MDX](https://mdxjs.com) as a language designation. MDX's website [recommends](https://mdxjs.com/editors#editor-plugins) a community-created extension called [MDX](https://marketplace.visualstudio.com/items?itemName=silvenon.mdx) for syntax highlighting in VS Code, and this extension adds the language ID `mdx`.

The reason that just the file extension `.mdx` isn't quite enough is because Next.js's MDX plugin allows [MDX parsing of `.md` files](https://mdxjs.com/getting-started/next#use-mdx-for-md-files). I ran into this problem in the process of writing a documentation PR for styled-components, whose website [uses this pattern](https://github.com/styled-components/styled-components-website/tree/804a309763e7344729bad0b5c6f81eeea420ab7a/pages/docs). To correct the syntax highlighting, I added the following file association to my VSCodium settings:

```json
"files.associations": {
  "**/pages/**/*.md": "mdx"
},
```

While this did fix the highlighting, it broke my file icons on those pages:

<img width="167" alt="Broken vscode-icons file icons" src="https://user-images.githubusercontent.com/5317080/101693438-9ad60500-3a3f-11eb-8722-17a05d21014e.png">

This change should fix that.