### PR TITLE
Add icon for Gulpfile.mjs

### DIFF
--- a/src/iconsManifest/supportedExtensions.ts
+++ b/src/iconsManifest/supportedExtensions.ts
@@ -1716,7 +1716,7 @@ export const extensions: IFileCollection = {
       icon: 'gulp',
       extensions: [],
       filenamesGlob: ['gulpfile', 'gulpfile.esm', 'gulpfile.babel'],
-      extensionsGlob: ['js', 'coffee', 'ts'],
+      extensionsGlob: ['js', 'coffee', 'ts', 'mjs'],
       filename: true,
       format: FileFormat.svg,
     },


### PR DESCRIPTION
<!-- markdownlint-disable MD041-->

<!-- Please first read how to submit a pull request, if you haven't already done so.
https://github.com/vscode-icons/vscode-icons/wiki/PullRequest -->

_**Fixes**_ N/A (search terms: [`gulpfile.mjs`](https://github.com/vscode-icons/vscode-icons/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc+gulpfile.mjs))

**Changes proposed:**

- [x] Add
- [ ] Delete
- [ ] Fix
- [ ] Prepare

---

Gulp supports the `.mjs` file extension for config files (tracked at https://github.com/gulpjs/interpret/issues/65).
It looks like `.cjs` is not supported yet (https://github.com/gulpjs/interpret/issues/68).
