### PR TITLE
Differentiate "unlicence" spelling variant

### DIFF
--- a/src/iconsManifest/supportedExtensions.ts
+++ b/src/iconsManifest/supportedExtensions.ts
@@ -3938,8 +3938,8 @@ export const extensions: IFileCollection = {
     },
     {
       icon: 'unlicense',
-      extensions: ['unlicense', 'unlicense'],
-      filenamesGlob: ['unlicense', 'unlicense'],
+      extensions: ['unlicense', 'unlicence'],
+      filenamesGlob: ['unlicense', 'unlicence'],
       extensionsGlob: ['md', 'txt'],
       filename: true,
       format: FileFormat.svg,


### PR DESCRIPTION
<!-- markdownlint-disable MD041-->

<!-- Please first read how to submit a pull request, if you haven't already done so.
https://github.com/vscode-icons/vscode-icons/wiki/PullRequest -->

_**References #2644, #2651**_

**Changes proposed:**

- [x] Fix

Just a quick follow-up to #2651—pretty sure the intent was to write `"unlicense", "unlicence"`, not `"unlicense"` twice. 👍🏼

```diff
 {
   icon: 'unlicense',
-  extensions: ['unlicense', 'unlicense'],
+  extensions: ['unlicense', 'unlicence'],
-  filenamesGlob: ['unlicense', 'unlicense'],
+  filenamesGlob: ['unlicense', 'unlicence'],
   extensionsGlob: ['md', 'txt'],
   filename: true,
   format: FileFormat.svg,
 },
```