### PR TITLE
fix(cfm): add more language ids

### DIFF
--- a/src/iconsManifest/languages.ts
+++ b/src/iconsManifest/languages.ts
@@ -44,7 +44,7 @@ export const languages: ILanguageCollection = {
   cddl: { ids: 'cddl', defaultExtension: 'cddl' },
   ceylon: { ids: 'ceylon', defaultExtension: 'ceylon' },
   cfc: { ids: 'cfc', defaultExtension: 'cfc' },
-  cfm: { ids: 'cfmhtml', defaultExtension: 'cfm' },
+  cfm: { ids: ['cfmhtml', 'cfml'], defaultExtension: 'cfm' },
   clojure: { ids: 'clojure', defaultExtension: 'clojure' },
   clojurescript: { ids: 'clojurescript', defaultExtension: 'clojurescript' },
   cloudfoundrymanifest: { ids: 'manifest-yaml', defaultExtension: 'yml' },


### PR DESCRIPTION
It seems CFM extensions are using a new language id. I've kept the old one in case some extension is
still using it although I have reviewed all the cfm extensions and they don't seem to be supporting
anymore.

fixes #2673