### PR TITLE
Fix license link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Kudos to all [contributors](https://github.com/vscode-icons/vscode-icons/graphs/
 
 ## License
 
-The source code is licensed under the [MIT](License) license.
+The source code is licensed under the [MIT](LICENSE) license.
 
 The icons are licensed under the [Creative Commons - ShareAlike (CC BY-SA)](https://creativecommons.org/licenses/by-sa/4.0/) license.
 


### PR DESCRIPTION
Link is currently broken because the casing doesn't match the filename.

<!-- markdownlint-disable MD041-->

<!-- Please first read how to submit a pull request, if you haven't already done so.
https://github.com/vscode-icons/vscode-icons/wiki/PullRequest -->

<!-- _**Fixes #IssueNumber**_ -->

**Changes proposed:**

- [ ] Add
- [ ] Delete
- [x] Fix
- [ ] Prepare
