### PR TITLE
chore(v11.4.0): prepare new version

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -1,5 +1,6 @@
 *
 */
+.DS_Store
 !dist/
 !icons/
 !images/*.png

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## 11.4.0 (April 04, 2021)
+
+- Feature: Support for `CodeQL`. ([@lrecknagel](https://github.com/lrecknagel) in [#2735](https://github.com/vscode-icons/vscode-icons/pull/2735))
+- Feature: Support for `Gitpod` config file. ([@mikenikles](https://github.com/mikenikles) in [#2696](https://github.com/vscode-icons/vscode-icons/pull/2696))
+
 ## 11.3.0 (April 02, 2021)
 
 - Enhancement: Update `JSP` icon to `Jakarta SP`. ([@KingDarBoja](https://github.com/KingDarBoja) in [#2743](https://github.com/vscode-icons/vscode-icons/pull/2743))

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "vscode-icons",
-  "version": "11.3.0",
+  "version": "11.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-icons",
   "displayName": "vscode-icons",
   "description": "Icons for Visual Studio Code",
-  "version": "11.3.0",
+  "version": "11.4.0",
   "publisher": "vscode-icons-team",
   "license": "MIT",
   "author": {


### PR DESCRIPTION
This version will be manually released by using docker instead of directly from @robertohuertasm mac machine. We suspect that this was causing #2165 again due to `.DS_Store` files being present. Hopefully, all this will get back to normal once we have travis again. On April 22 we will receive our first sponsorship which will allow us to pay for our release pipelines.