### PR TITLE
Fix manifest entry for "pipeline"

### DIFF
--- a/src/iconsManifest/supportedExtensions.ts
+++ b/src/iconsManifest/supportedExtensions.ts
@@ -2972,7 +2972,6 @@ export const extensions: IFileCollection = {
     {
       icon: 'pipeline',
       extensions: ['pipeline'],
-      filename: true,
       format: FileFormat.svg,
     },
     {


### PR DESCRIPTION
<!-- markdownlint-disable MD041-->

**Changes proposed:**

- [ ] Add
- [ ] Delete
- [X] Fix
- [ ] Prepare

In my previous PR I accidentally included `filename: true`, but this icon should be for applied to any file with a `.pipeline` extension. For example: `example.pipeline`
