### PR TITLE
fix(vsce): fix the vsce version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,7 +54,7 @@ jobs:
       os: linux
       node_js: 12.4.0
       before_script: skip
-      script: npx vsce publish -p $VSCE_TOKEN
+      script: npx vsce@1.88.0 publish -p $VSCE_TOKEN
       after_script: skip
 
     - stage: docker vsi:latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 11.5.0 (June 13, 2021)
 
+- Fix: Set `vsce` version to 1.88.0. ([@robertohuertasm](https://github.com/robertohuertasm) in [#2796](https://github.com/vscode-icons/vscode-icons/pull/2796))
 - Enhancement: Added light version of the  `Rust toolchain` icon. ([@robertohuertasm](https://github.com/robertohuertasm) in [#2794](https://github.com/vscode-icons/vscode-icons/pull/2794))
 - Feature: Support for `Licensebat` configuration file. ([@robertohuertasm](https://github.com/robertohuertasm) in [#2793](https://github.com/vscode-icons/vscode-icons/pull/2793))
 - Feature: Support for untrusted workspaces. ([@robertohuertasm](https://github.com/robertohuertasm) in [#2792](https://github.com/vscode-icons/vscode-icons/pull/2792))


### PR DESCRIPTION
New 1.93.0 version makes the publication fail with an error saying that the The specified icon 'extension/images/logo.png' wasn't found in the extension.

I looked into vsce issues and there was one related which was closed without any answer in 2018. I'll get back to it at some point, but for the moment I will merge this to unblock our release.
