### PR TITLE
Add missing postcss config extensions

### DIFF
--- a/src/iconsManifest/supportedExtensions.ts
+++ b/src/iconsManifest/supportedExtensions.ts
@@ -3070,8 +3070,12 @@ export const extensions: IFileCollection = {
       extensions: [
         '.postcssrc',
         '.postcssrc.json',
+        '.postcssrc.yaml',
         '.postcssrc.yml',
+        '.postcssrc.ts',
         '.postcssrc.js',
+        '.postcssrc.cjs',
+        'postcss.config.ts',
         'postcss.config.js',
         'postcss.config.cjs',
       ],


### PR DESCRIPTION
The list of supported filenames can be found on
https://github.com/postcss/postcss-load-config/blob/d1478640e823b5432b7dc43a0ba6e23c58b7b981/src/index.js#L77-L86

**Changes proposed:**

- [x] Add
- [ ] Delete
- [ ] Fix
- [ ] Prepare
