### PR TITLE
feat(helm): Use Helm icon for Chart.lock and Chart.yaml

### DIFF
--- a/src/iconsManifest/supportedExtensions.ts
+++ b/src/iconsManifest/supportedExtensions.ts
@@ -1856,7 +1856,8 @@ export const extensions: IFileCollection = {
     },
     {
       icon: 'helm',
-      extensions: ['Chart.lock', 'Chart.yaml'],
+      extensions: ['chart.lock', 'chart.yaml'],
+      filename: true,
       languages: [languages.helm],
       format: FileFormat.svg,
     },

--- a/src/iconsManifest/supportedExtensions.ts
+++ b/src/iconsManifest/supportedExtensions.ts
@@ -1856,7 +1856,7 @@ export const extensions: IFileCollection = {
     },
     {
       icon: 'helm',
-      extensions: [],
+      extensions: ['Chart.lock', 'Chart.yaml'],
       languages: [languages.helm],
       format: FileFormat.svg,
     },


### PR DESCRIPTION
Currently `Chart.yaml` incorrectly has a Helm template language mode. However, it’s a regular YAML file. This has been corrected in https://github.com/Azure/vscode-kubernetes-tools/pull/948.

Both `Chart.lock` and `Chart.yaml` are related to Helm charts though. It makes sense to use the Helm icon.

The same could be said about `values.yaml` and `values.schema.json`, but personally I believe those names are too generic to assign a special icon to them.

<!-- markdownlint-disable MD041-->

<!-- Please first read how to submit a pull request, if you haven't already done so.
https://github.com/vscode-icons/vscode-icons/wiki/PullRequest -->

**Changes proposed:**

- [x] Add
- [ ] Delete
- [ ] Fix
- [ ] Prepare
