### PR TITLE
Add .devcontainer.json to devcontainer file extensions

### DIFF
--- a/src/iconsManifest/supportedExtensions.ts
+++ b/src/iconsManifest/supportedExtensions.ts
@@ -1202,7 +1202,7 @@ export const extensions: IFileCollection = {
     },
     {
       icon: 'devcontainer',
-      extensions: ['devcontainer.json'],
+      extensions: ['devcontainer.json', '.devcontainer.json'],
       filename: true,
       format: FileFormat.svg,
     },


### PR DESCRIPTION
<!-- markdownlint-disable MD041-->

<!-- Please first read how to submit a pull request, if you haven't already done so.
https://github.com/vscode-icons/vscode-icons/wiki/PullRequest -->

**Changes proposed:**

- [x] Add
- [ ] Delete
- [ ] Fix
- [ ] Prepare


Apparently VS Code supports both [`devcontainer/devcontainer.json` and `.devcontainer.json` in the root of the project](https://code.visualstudio.com/docs/remote/create-dev-container#_create-a-devcontainerjson-file), so I added `.devcontainer.json` to the `extensions` field for the `devcontainer` icon.

Assuming that this change is okay, I'm unsure if I should update the Wiki or if that's something you do (or if it's automated). Just let me know!
