### PR TITLE
chore: replace vsmarketplacebadge with shields

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # vscode-icons
 
-[![Version](https://vsmarketplacebadge.apphb.com/version/vscode-icons-team.vscode-icons.svg)](https://marketplace.visualstudio.com/items?itemName=vscode-icons-team.vscode-icons)
-[![Installs](https://vsmarketplacebadge.apphb.com/installs-short/vscode-icons-team.vscode-icons.svg)](https://marketplace.visualstudio.com/items?itemName=vscode-icons-team.vscode-icons)
-[![Ratings](https://vsmarketplacebadge.apphb.com/rating/vscode-icons-team.vscode-icons.svg)](https://marketplace.visualstudio.com/items?itemName=vscode-icons-team.vscode-icons)
+[![Version](https://img.shields.io/visual-studio-marketplace/v/vscode-icons-team.vscode-icons?label=VSCode%20Marketplace)](https://marketplace.visualstudio.com/items?itemName=vscode-icons-team.vscode-icons)
+[![Installs](https://img.shields.io/visual-studio-marketplace/i/vscode-icons-team.vscode-icons)](https://marketplace.visualstudio.com/items?itemName=vscode-icons-team.vscode-icons)
+[![Ratings](https://img.shields.io/visual-studio-marketplace/r/vscode-icons-team.vscode-icons)](https://marketplace.visualstudio.com/items?itemName=vscode-icons-team.vscode-icons)
 
 [![Build Status](https://travis-ci.org/vscode-icons/vscode-icons.svg?branch=master)](https://travis-ci.org/vscode-icons/vscode-icons)
 [![Build Status](https://ci.appveyor.com/api/projects/status/github/vscode-icons/vscode-icons?branch=master&svg=true)](https://ci.appveyor.com/project/vscode-icons-team/vscode-icons)


### PR DESCRIPTION
<!-- markdownlint-disable MD041-->

<!-- Please first read how to submit a pull request, if you haven't already done so.
https://github.com/vscode-icons/vscode-icons/wiki/PullRequest -->
_**Fixes #IssueNumber**_

vsmarketplacebadge services down, use shields.io directly

**Changes proposed:**

- [ ] Add
- [ ] Delete
- [x] Fix
- [ ] Prepare

## before
![2021-09-08 22 50 13](https://user-images.githubusercontent.com/14012511/132532490-606364da-7dc0-464c-abdf-80d3e4abe89f.png)

## after
![2021-09-08 22 50 57](https://user-images.githubusercontent.com/14012511/132532623-d6493662-8cc0-49bb-b50e-8ad65baf09de.png)

cc @robertohuertasm @KingDarBoja 