### PR TITLE
Adds support for `FortranFixedForm`

### DIFF
--- a/src/iconsManifest/languages.ts
+++ b/src/iconsManifest/languages.ts
@@ -89,7 +89,13 @@ export const languages: ILanguageCollection = {
   falcon: { ids: 'falcon', defaultExtension: 'falcon' },
   fauna: { ids: 'fql', defaultExtension: 'fql' },
   fortran: {
-    ids: ['fortran', 'fortran-modern', 'FortranFreeForm', 'fortran_fixed-form'],
+    ids: [
+      'fortran',
+      'fortran-modern',
+      'FortranFreeForm',
+      'FortranFixedForm',
+      'fortran_fixed-form',
+    ],
     defaultExtension: 'f',
   },
   freemarker: { ids: 'ftl', defaultExtension: 'ftl' },


### PR DESCRIPTION
`fortran_fixed-form` is being deprecated but it has been left in
for backwards compatibility

<!-- markdownlint-disable MD041-->

<!-- Please first read how to submit a pull request, if you haven't already done so.
https://github.com/vscode-icons/vscode-icons/wiki/PullRequest -->

_**Fixes #2839**_

**Changes proposed:**

- [X] Adds support for `FortranFixedForm`

## Note

Not sure how you edit your CHANGELOG, but if you need me to update it let me know.