### PR TITLE
Add pluralized extension 'jsons' to json folder icon

### DIFF
--- a/src/iconsManifest/supportedFolders.ts
+++ b/src/iconsManifest/supportedFolders.ts
@@ -316,7 +316,11 @@ export const extensions: IFolderCollection = {
     },
     { icon: 'ios', extensions: ['ios'], format: FileFormat.svg },
     { icon: 'js', extensions: ['js'], format: FileFormat.svg },
-    { icon: 'json', extensions: ['json'], format: FileFormat.svg },
+    {
+      icon: 'json',
+      extensions: ['json', 'jsons'],
+      format: FileFormat.svg
+    },
     {
       icon: 'json_official',
       extensions: ['json'],
@@ -333,7 +337,7 @@ export const extensions: IFolderCollection = {
         '.kubernetes',
         '.k8s',
         '.kube',
-        '.kuber',
+        '.kuber'
       ],
       format: FileFormat.svg,
     },

--- a/src/iconsManifest/supportedFolders.ts
+++ b/src/iconsManifest/supportedFolders.ts
@@ -319,7 +319,7 @@ export const extensions: IFolderCollection = {
     {
       icon: 'json',
       extensions: ['json', 'jsons'],
-      format: FileFormat.svg
+      format: FileFormat.svg,
     },
     {
       icon: 'json_official',
@@ -344,7 +344,7 @@ export const extensions: IFolderCollection = {
     { icon: 'less', extensions: ['less', '_less'], format: FileFormat.svg },
     {
       icon: 'library',
-      extensions: ['lib', 'libs', '.lib', '.libs', 'library', 'libraries',],
+      extensions: ['lib', 'libs', '.lib', '.libs', 'library', 'libraries'],
       format: FileFormat.svg,
     },
     { icon: 'linux', extensions: ['linux'], format: FileFormat.svg },

--- a/src/iconsManifest/supportedFolders.ts
+++ b/src/iconsManifest/supportedFolders.ts
@@ -337,14 +337,14 @@ export const extensions: IFolderCollection = {
         '.kubernetes',
         '.k8s',
         '.kube',
-        '.kuber'
+        '.kuber',
       ],
       format: FileFormat.svg,
     },
     { icon: 'less', extensions: ['less', '_less'], format: FileFormat.svg },
     {
       icon: 'library',
-      extensions: ['lib', 'libs', '.lib', '.libs', 'library', 'libraries'],
+      extensions: ['lib', 'libs', '.lib', '.libs', 'library', 'libraries',],
       format: FileFormat.svg,
     },
     { icon: 'linux', extensions: ['linux'], format: FileFormat.svg },


### PR DESCRIPTION
<!-- markdownlint-disable MD041-->

<!-- Please first read how to submit a pull request, if you haven't already done so.
https://github.com/vscode-icons/vscode-icons/wiki/PullRequest -->

**Changes proposed:**

- [x] Add

This is my first ever pull request! Hello!

Anyway, this change simply adds the extension `jsons` to the json folder icon extensions list. Reason being that there is an `images` extension for the image folder, `audios` for the audio folder, `videos` for the video folder, and it goes on.

I would've also made a pull request to the wiki to add `jsons` to the folder page, but I don't know how to clone wikis.