### PR TITLE
feat(prettier): support toml extension

### DIFF
--- a/src/iconsManifest/supportedExtensions.ts
+++ b/src/iconsManifest/supportedExtensions.ts
@@ -3215,7 +3215,7 @@ export const extensions: IFileCollection = {
       icon: 'prettier',
       extensions: [],
       filenamesGlob: ['.prettierrc'],
-      extensionsGlob: ['js', 'cjs', 'json', 'json5', 'yml', 'yaml'],
+      extensionsGlob: ['js', 'cjs', 'json', 'json5', 'yml', 'yaml', 'toml'],
       light: true,
       filename: true,
       format: FileFormat.svg,


### PR DESCRIPTION
Use the prettier icon for `.prettierrc.toml`.

According to the [prettier config docs](https://prettier.io/docs/en/configuration.html), this is supported.