### PR TITLE
Add `cuda-cpp` to `ids` item for cuda language.

### DIFF
--- a/src/iconsManifest/languages.ts
+++ b/src/iconsManifest/languages.ts
@@ -63,7 +63,7 @@ export const languages: ILanguageCollection = {
   csharp: { ids: 'csharp', defaultExtension: 'cs' },
   css: { ids: 'css', defaultExtension: 'css' },
   cucumber: { ids: 'feature', defaultExtension: 'feature' },
-  cuda: { ids: 'cuda', defaultExtension: 'cu' },
+  cuda: { ids: ['cuda', 'cuda-cpp'], defaultExtension: 'cu' },
   cython: { ids: 'cython', defaultExtension: 'pyx' },
   dal: { ids: 'dal', defaultExtension: 'dal' },
   dart: { ids: 'dart', defaultExtension: 'dart' },


### PR DESCRIPTION
<!-- markdownlint-disable MD041-->

<!-- Please first read how to submit a pull request, if you haven't already done so.
https://github.com/vscode-icons/vscode-icons/wiki/PullRequest -->

**Changes proposed:**

- [x] Add

For those who don't use [`vscode-cudacpp`](https://marketplace.visualstudio.com/items?itemName=kriegalex.vscode-cudacpp) extension like me, `vscode-icons` will not change `*.cu` and `*.cuh` files' icon. The icon for "CUDA C++" item in `Select Language Mode` dialog box is also blank.

But there exsists a default language mode for CUDA called `cuda-cpp`, adding this to `ids` for `cuda` helps a lot.
