### PR TITLE
feat(icon): add new extensionGlob for Gatsby

### DIFF
--- a/src/iconsManifest/supportedExtensions.ts
+++ b/src/iconsManifest/supportedExtensions.ts
@@ -1674,7 +1674,7 @@ export const extensions: IFileCollection = {
     {
       icon: 'gatsby',
       extensions: [],
-      filenamesGlob: ['gatsby-browser'],
+      filenamesGlob: ['gatsby-browser', 'gatsby-ssr'],
       extensionsGlob: ['js', 'ts', 'tsx'],
       filename: true,
       format: FileFormat.svg,
@@ -1682,7 +1682,7 @@ export const extensions: IFileCollection = {
     {
       icon: 'gatsby',
       extensions: [],
-      filenamesGlob: ['gatsby-config', 'gatsby-node', 'gatsby-ssr'],
+      filenamesGlob: ['gatsby-config', 'gatsby-node'],
       extensionsGlob: ['js', 'ts'],
       filename: true,
       format: FileFormat.svg,

--- a/src/iconsManifest/supportedExtensions.ts
+++ b/src/iconsManifest/supportedExtensions.ts
@@ -1674,13 +1674,16 @@ export const extensions: IFileCollection = {
     {
       icon: 'gatsby',
       extensions: [],
-      filenamesGlob: [
-        'gatsby-config',
-        'gatsby-node',
-        'gatsby-browser',
-        'gatsby-ssr',
-      ],
+      filenamesGlob: ['gatsby-browser'],
       extensionsGlob: ['js', 'ts', 'tsx'],
+      filename: true,
+      format: FileFormat.svg,
+    },
+    {
+      icon: 'gatsby',
+      extensions: [],
+      filenamesGlob: ['gatsby-config', 'gatsby-node', 'gatsby-ssr'],
+      extensionsGlob: ['js', 'ts'],
       filename: true,
       format: FileFormat.svg,
     },

--- a/src/iconsManifest/supportedExtensions.ts
+++ b/src/iconsManifest/supportedExtensions.ts
@@ -1680,7 +1680,7 @@ export const extensions: IFileCollection = {
         'gatsby-browser',
         'gatsby-ssr',
       ],
-      extensionsGlob: ['js', 'ts'],
+      extensionsGlob: ['js', 'ts','tsx'],
       filename: true,
       format: FileFormat.svg,
     },

--- a/src/iconsManifest/supportedExtensions.ts
+++ b/src/iconsManifest/supportedExtensions.ts
@@ -1680,7 +1680,7 @@ export const extensions: IFileCollection = {
         'gatsby-browser',
         'gatsby-ssr',
       ],
-      extensionsGlob: ['js', 'ts','tsx'],
+      extensionsGlob: ['js', 'ts', 'tsx'],
       filename: true,
       format: FileFormat.svg,
     },


### PR DESCRIPTION
<!-- markdownlint-disable MD041-->

<!-- Please first read how to submit a pull request, if you haven't already done so.
https://github.com/vscode-icons/vscode-icons/wiki/PullRequest -->

Show icon for `gatsby-browser.tsx` and `gatsby-ssr.tsx` as Gatsby is working on supporting TS out of the box. 

**Changes proposed:**

- [x] Add
- [ ] Delete
- [ ] Fix
- [ ] Prepare
