### PR TITLE
fix(constants): make link in notification point to current release notes

### DIFF
--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -43,7 +43,7 @@ export const constants = {
       'vsicons.projectDetection.disableDetect',
   },
   urlReleaseNote:
-    'https://github.com/vscode-icons/vscode-icons/blob/master/CHANGELOG.md',
+    'https://github.com/vscode-icons/vscode-icons/releases',
   urlReadme:
     'https://github.com/vscode-icons/vscode-icons/blob/master/README.md',
   urlOfficialApi:


### PR DESCRIPTION
<!-- markdownlint-disable MD041-->

<!-- Please first read how to submit a pull request, if you haven't already done so.
https://github.com/vscode-icons/vscode-icons/wiki/PullRequest -->

- [x] Fix

Changed the link in `constants` so that users can go directly to the [Releases](https://github.com/vscode-icons/vscode-icons/releases) page with the current release notes since the use of the previous one was stopped in December 2021.