### PR TITLE
fix: Changelog URL pointing to old changelog

### DIFF
--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -43,7 +43,7 @@ export const constants = {
       'vsicons.projectDetection.disableDetect',
   },
   urlReleaseNote:
-    'https://github.com/vscode-icons/vscode-icons/blob/master/CHANGELOG.md',
+    'https://github.com/vscode-icons/vscode-icons/releases',
   urlReadme:
     'https://github.com/vscode-icons/vscode-icons/blob/master/README.md',
   urlOfficialApi:


### PR DESCRIPTION
**Changes proposed:**

- [ ] Add
- [ ] Delete
- [x] Fix
- [ ] Prepare

Fixes the "View Updates for new release" extension prompt leading to the old changelog.