### PR TITLE
fix(drawio): extensionsGlob should be empty

### DIFF
--- a/src/iconsManifest/supportedExtensions.ts
+++ b/src/iconsManifest/supportedExtensions.ts
@@ -1344,7 +1344,7 @@ export const extensions: IFileCollection = {
       icon: 'drawio',
       extensions: ['drawio', 'dio'],
       filenamesGlob: ['.drawio'],
-      extensionsGlob: ['png', 'svg'],
+      extensionsGlob: [],
       format: FileFormat.svg,
     },
     {


### PR DESCRIPTION
_**Fixes #2947**_

**Changes proposed:**

.drawio extensionsGlob should be empty!