### PR TITLE
Support .commitlintrc configuration file

### DIFF
--- a/src/iconsManifest/supportedExtensions.ts
+++ b/src/iconsManifest/supportedExtensions.ts
@@ -1056,6 +1056,12 @@ export const extensions: IFileCollection = {
     },
     {
       icon: 'commitlint',
+      extensions: ['.commitlintrc'],
+      filename: true,
+      format: FileFormat.svg,
+    },
+    {
+      icon: 'commitlint',
       extensions: [
         'commitlint.config.js',
         'commitlint.config.cjs',


### PR DESCRIPTION
From [commitlint docs](https://github.com/conventional-changelog/commitlint#shared-configuration): `.commitlintrc` configuration file is also supported.

<!-- markdownlint-disable MD041-->

<!-- Please first read how to submit a pull request, if you haven't already done so.
https://github.com/vscode-icons/vscode-icons/wiki/PullRequest -->

**Changes proposed:**

- [x] Add support for `.commitlintrc` configuration file.
- [ ] Delete
- [ ] Fix
- [ ] Prepare
