### PR TITLE
refactor(eslint): add tsconfig.eslint.json

### DIFF
--- a/src/iconsManifest/supportedExtensions.ts
+++ b/src/iconsManifest/supportedExtensions.ts
@@ -1497,7 +1497,7 @@ export const extensions: IFileCollection = {
     {
       icon: 'eslint',
       extensions: ['.eslintrc', '.eslintignore', '.eslintcache'],
-      filenamesGlob: ['.eslintrc', 'tsconfig.eslint.json'],
+      filenamesGlob: ['.eslintrc'],
       extensionsGlob: ['js', 'mjs', 'cjs', 'json', 'yaml', 'yml'],
       filename: true,
       format: FileFormat.svg,
@@ -4192,6 +4192,7 @@ export const extensions: IFileCollection = {
         'tsconfig.dev',
         'tsconfig.development',
         'tsconfig.e2e',
+        'tsconfig.eslint',
         'tsconfig.node',
         'tsconfig.prod',
         'tsconfig.production',

--- a/src/iconsManifest/supportedExtensions.ts
+++ b/src/iconsManifest/supportedExtensions.ts
@@ -1497,7 +1497,7 @@ export const extensions: IFileCollection = {
     {
       icon: 'eslint',
       extensions: ['.eslintrc', '.eslintignore', '.eslintcache'],
-      filenamesGlob: ['.eslintrc'],
+      filenamesGlob: ['.eslintrc', 'tsconfig.eslint.json'],
       extensionsGlob: ['js', 'mjs', 'cjs', 'json', 'yaml', 'yml'],
       filename: true,
       format: FileFormat.svg,


### PR DESCRIPTION
**Changes proposed:**

tsconfig.eslint.json is commonly used in TypeScript eslint. 
It is also mentioned [in the docs](https://typescript-eslint.io/docs/linting/type-linting#i-get-errors-telling-me-the-file-must-be-included-in-at-least-one-of-the-projects-provided)!
