### PR TITLE
ci(github): fix test workflow

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -6,7 +6,7 @@ on:
       - '!*'
     branches:
       - '*'
-  pull_request:
+  pull_request_target:
     tags:
       - '!*'
     branches:
@@ -38,5 +38,6 @@ jobs:
         env:
           CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}
         with:
+          coverageCommand: npm test
           coverageLocations: |
             ${{github.workspace}}/coverage/lcov.info:lcov


### PR DESCRIPTION
<!-- markdownlint-disable MD041-->

I should've probably done this before #2994 (and #3080) was merged, but didn't realize till now.

Test workflow now uses `pull_request_target`, fixing that issue about secrets not working:
> This event is similar to `pull_request`, except that it runs in the context of the base repository of the pull request, rather than in the merge commit. This means that you can more safely make your secrets available to the workflows triggered by the pull request, because only workflows defined in the commit on the base repository are run.

This would apparently have to be merged to master before it starts working, so this PR might just fail checks anyways.

Also added `coverageCommand` to the codeclimate step, which should've been there already:
![](https://get.snaz.in/4RykVaN.png)

**Changes proposed:**

- [ ] Add
- [ ] Delete
- [x] Fix
- [ ] Prepare
