### PR TITLE
fix(defaults): allow to use bundled icons for default files/folders

### DIFF
--- a/src/iconsManifest/manifestBuilder.ts
+++ b/src/iconsManifest/manifestBuilder.ts
@@ -28,26 +28,29 @@ export class ManifestBuilder {
     defs._file.iconPath = await this.buildDefaultIconPath(
       files.default.file,
       defs._file,
-      false,
     );
     defs._folder.iconPath = await this.buildDefaultIconPath(
       folders.default.folder,
       defs._folder,
+      true,
       false,
     );
     defs._folder_open.iconPath = await this.buildDefaultIconPath(
       folders.default.folder,
       defs._folder_open,
       true,
+      true,
     );
     defs._root_folder.iconPath = await this.buildDefaultIconPath(
       folders.default.root_folder,
       defs._root_folder,
+      true,
       false,
     );
     defs._root_folder_open.iconPath = await this.buildDefaultIconPath(
       folders.default.root_folder,
       defs._root_folder_open,
+      true,
       true,
     );
 
@@ -62,26 +65,29 @@ export class ManifestBuilder {
     defs._file_light.iconPath = await this.buildDefaultIconPath(
       files.default.file_light,
       defs._file_light,
-      false,
     );
     defs._folder_light.iconPath = await this.buildDefaultIconPath(
       folders.default.folder_light,
       defs._folder_light,
+      true,
       false,
     );
     defs._folder_light_open.iconPath = await this.buildDefaultIconPath(
       folders.default.folder_light,
       defs._folder_light_open,
       true,
+      true,
     );
     defs._root_folder_light.iconPath = await this.buildDefaultIconPath(
       folders.default.root_folder_light,
       defs._root_folder_light,
+      true,
       false,
     );
     defs._root_folder_light_open.iconPath = await this.buildDefaultIconPath(
       folders.default.root_folder_light,
       defs._root_folder_light_open,
+      true,
       true,
     );
 
@@ -92,12 +98,17 @@ export class ManifestBuilder {
   private static async buildDefaultIconPath(
     defaultExtension: models.IDefaultExtension,
     schemaExtension: models.IIconPath,
-    isOpenFolder: boolean,
+    isFolder = false,
+    isOpenFolder = false,
   ): Promise<string> {
     if (!defaultExtension || defaultExtension.disabled) {
       return schemaExtension.iconPath || '';
     }
-    const defPrefix = constants.iconsManifest.defaultPrefix;
+    const defPrefix = !defaultExtension.useBundledIcon
+      ? constants.iconsManifest.defaultPrefix
+      : isFolder
+      ? constants.iconsManifest.folderTypePrefix
+      : constants.iconsManifest.fileTypePrefix;
     const openSuffix = isOpenFolder ? '_opened' : '';
     const iconSuffix = constants.iconsManifest.iconSuffix;
     const icon = defaultExtension.icon;

--- a/src/models/extensions/defaultExtension.ts
+++ b/src/models/extensions/defaultExtension.ts
@@ -13,4 +13,9 @@ export interface IDefaultExtension {
    * user customization: if false the extension won't be exported.
    */
   disabled?: boolean;
+  /**
+   * set this to true if you want to use a bundle icon.
+   * This will override the `default` prefix with the one for files or folders.
+   */
+  useBundledIcon?: boolean;
 }

--- a/test/iconsManifest/manifestBuilder/files.test.ts
+++ b/test/iconsManifest/manifestBuilder/files.test.ts
@@ -1,6 +1,7 @@
 /* eslint-disable prefer-arrow-callback */
 /* eslint-disable no-unused-expressions */
 import { expect } from 'chai';
+import { cloneDeep } from 'lodash';
 import * as sinon from 'sinon';
 import * as fsAsync from '../../../src/common/fsAsync';
 import { constants } from '../../../src/constants';
@@ -56,6 +57,28 @@ describe('ManifestBuilder: files icons test', function () {
     });
 
     context(`if a default 'light' icon is NOT defined`, function () {
+      context('and useBundledIcon is enabled', function () {
+        it(`the 'default' file icon path has the correct structure`, async function () {
+          const filename = `${constants.iconsManifest.fileTypePrefix}${
+            fixtFiles.default.file.icon
+          }${constants.iconsManifest.iconSuffix}${Utils.fileFormatToString(
+            fixtFiles.default.file.format,
+          )}`;
+
+          const files = cloneDeep(fixtFiles);
+          files.default.file.useBundledIcon = true;
+
+          const manifest = await ManifestBuilder.buildManifest(
+            files,
+            emptyFolderCollection,
+          );
+
+          expect(manifest.iconDefinitions._file.iconPath).to.equal(
+            `${iconsDirRelativeBasePath}/${filename}`,
+          );
+        });
+      });
+
       context(`the 'default' file`, function () {
         it(`has an icon path`, async function () {
           const manifest = await ManifestBuilder.buildManifest(
@@ -622,6 +645,28 @@ describe('ManifestBuilder: files icons test', function () {
 
       afterEach(function () {
         fixtFiles.default.file_light = undefined;
+      });
+
+      context('and useBundledIcon is enabled', function () {
+        it(`the 'default' file icon path has the correct structure`, async function () {
+          const filename = `${constants.iconsManifest.fileTypePrefix}${
+            fixtFiles.default.file.icon
+          }${constants.iconsManifest.iconSuffix}${Utils.fileFormatToString(
+            fixtFiles.default.file.format,
+          )}`;
+
+          const files = cloneDeep(fixtFiles);
+          files.default.file.useBundledIcon = true;
+
+          const manifest = await ManifestBuilder.buildManifest(
+            files,
+            emptyFolderCollection,
+          );
+
+          expect(manifest.iconDefinitions._file.iconPath).to.equal(
+            `${iconsDirRelativeBasePath}/${filename}`,
+          );
+        });
       });
 
       context(`the 'default' file`, function () {

--- a/test/iconsManifest/manifestBuilder/folders.test.ts
+++ b/test/iconsManifest/manifestBuilder/folders.test.ts
@@ -1,6 +1,7 @@
 /* eslint-disable prefer-arrow-callback */
 /* eslint-disable no-unused-expressions */
 import { expect } from 'chai';
+import { cloneDeep } from 'lodash';
 import * as sinon from 'sinon';
 import * as fsAsync from '../../../src/common/fsAsync';
 import { constants } from '../../../src/constants';
@@ -42,6 +43,50 @@ describe('ManifestBuilder: folders icons test', function () {
     });
 
     context(`if a default 'light' icon is NOT defined`, function () {
+      context('and useBundledIcon is enabled', function () {
+        it(`the 'default' folder icon path has the correct structure`, async function () {
+          const filename = `${constants.iconsManifest.folderTypePrefix}${
+            fixtFolders.default.folder.icon
+          }${constants.iconsManifest.iconSuffix}${Utils.fileFormatToString(
+            fixtFolders.default.folder.format,
+          )}`;
+
+          const folders = cloneDeep(fixtFolders);
+
+          folders.default.folder.useBundledIcon = true;
+
+          const manifest = await ManifestBuilder.buildManifest(
+            emptyFileCollection,
+            folders,
+          );
+
+          expect(manifest.iconDefinitions._folder.iconPath).to.equal(
+            `${iconsDirRelativeBasePath}/${filename}`,
+          );
+        });
+
+        it(`the 'default' open folder icon path has the correct structure`, async function () {
+          const filename = `${constants.iconsManifest.folderTypePrefix}${
+            fixtFolders.default.folder.icon
+          }_opened${
+            constants.iconsManifest.iconSuffix
+          }${Utils.fileFormatToString(fixtFolders.default.folder.format)}`;
+
+          const folders = cloneDeep(fixtFolders);
+
+          folders.default.folder.useBundledIcon = true;
+
+          const manifest = await ManifestBuilder.buildManifest(
+            emptyFileCollection,
+            folders,
+          );
+
+          expect(manifest.iconDefinitions._folder_open.iconPath).to.equal(
+            `${iconsDirRelativeBasePath}/${filename}`,
+          );
+        });
+      });
+
       context(`the 'default' folder`, function () {
         it(`has an icon path`, async function () {
           const manifest = await ManifestBuilder.buildManifest(
@@ -787,6 +832,50 @@ describe('ManifestBuilder: folders icons test', function () {
 
       afterEach(function () {
         fixtFolders.default.folder_light = undefined;
+      });
+
+      context('and useBundledIcon is enabled', function () {
+        it(`the 'default' folder icon path has the correct structure`, async function () {
+          const filename = `${constants.iconsManifest.folderTypePrefix}${
+            fixtFolders.default.folder.icon
+          }${constants.iconsManifest.iconSuffix}${Utils.fileFormatToString(
+            fixtFolders.default.folder.format,
+          )}`;
+
+          const folders = cloneDeep(fixtFolders);
+
+          folders.default.folder.useBundledIcon = true;
+
+          const manifest = await ManifestBuilder.buildManifest(
+            emptyFileCollection,
+            folders,
+          );
+
+          expect(manifest.iconDefinitions._folder.iconPath).to.equal(
+            `${iconsDirRelativeBasePath}/${filename}`,
+          );
+        });
+
+        it(`the 'default' open folder icon path has the correct structure`, async function () {
+          const filename = `${constants.iconsManifest.folderTypePrefix}${
+            fixtFolders.default.folder.icon
+          }_opened${
+            constants.iconsManifest.iconSuffix
+          }${Utils.fileFormatToString(fixtFolders.default.folder.format)}`;
+
+          const folders = cloneDeep(fixtFolders);
+
+          folders.default.folder.useBundledIcon = true;
+
+          const manifest = await ManifestBuilder.buildManifest(
+            emptyFileCollection,
+            folders,
+          );
+
+          expect(manifest.iconDefinitions._folder_open.iconPath).to.equal(
+            `${iconsDirRelativeBasePath}/${filename}`,
+          );
+        });
       });
 
       context(`the 'default' folder`, function () {


### PR DESCRIPTION
Adds a new property to the `IDefaultExtension` interface to allow the usage of bundled icons.

This basically allows anyone to use not only custom icons but use the bundled icons as default folders and files. Note that only folder icons can be assigned to default folder and root_folder.

fix #3103


