### PR TITLE
chore(sponsor): add extension sponsor url

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,9 @@
     "portable mode ready"
   ],
   "homepage": "https://github.com/vscode-icons/vscode-icons",
+  "sponsor": {
+    "url": "https://github.com/sponsors/vscode-icons"
+  },
   "main": "out/src/",
   "icon": "images/logo.png",
   "scripts": {


### PR DESCRIPTION
**Changes proposed:**

- [x] Add
- [ ] Delete
- [ ] Fix
- [ ] Prepare

The sponsor link is rendered in the header of the extension page in VSCode. For example:

![](https://user-images.githubusercontent.com/779047/187235503-d3a7e973-f107-4ef0-947b-cfe060e8d6e4.png)
