### PR TITLE
chore(domain): update vscode icons domain

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "multi-root ready",
     "portable mode ready"
   ],
-  "homepage": "https://github.com/vscode-icons/vscode-icons",
+  "homepage": "https://vscodeicons.team",
   "sponsor": {
     "url": "https://github.com/sponsors/vscode-icons"
   },


### PR DESCRIPTION
Now we own the vscodeicons.team domain.

<!-- markdownlint-disable MD041-->

<!-- Please first read how to submit a pull request, if you haven't already done so.
https://github.com/vscode-icons/vscode-icons/wiki/PullRequest -->

_**Fixes #IssueNumber**_

**Changes proposed:**

- [ ] Add
- [ ] Delete
- [ ] Fix
- [ ] Prepare
