### PR TITLE
feat(icon): add static to css folder icon

### DIFF
--- a/src/iconsManifest/supportedFolders.ts
+++ b/src/iconsManifest/supportedFolders.ts
@@ -143,7 +143,7 @@ export const extensions: IFolderCollection = {
       format: FileFormat.svg,
     },
     { icon: 'coverage', extensions: ['coverage'], format: FileFormat.svg },
-    { icon: 'css', extensions: ['css', '_css'], format: FileFormat.svg },
+    { icon: 'css', extensions: ['css', '_css', 'static'], format: FileFormat.svg },
     { icon: 'cubit', extensions: ['cubits', 'cubit'], format: FileFormat.svg },
     {
       icon: 'cypress',


### PR DESCRIPTION
<!-- markdownlint-disable MD041-->

<!-- Please first read how to submit a pull request, if you haven't already done so.
https://github.com/vscode-icons/vscode-icons/wiki/PullRequest -->

**Changes proposed:**

- [x] Add
- [ ] Delete
- [ ] Fix
- [ ] Prepare

Folders named static are usually used for storing CSS files of project.
