### PR TITLE
feat(icon): support the browserslist language

### DIFF
--- a/src/iconsManifest/languages.ts
+++ b/src/iconsManifest/languages.ts
@@ -47,6 +47,7 @@ export const languages: ILanguageCollection = {
   blitzbasic: { ids: ['blitzbasic'], defaultExtension: 'blitzbasic' },
   bolt: { ids: 'bolt', defaultExtension: 'bolt' },
   bosque: { ids: 'bosque', defaultExtension: 'bsq' },
+  browserslist: { ids: 'browserslist', defaultExtension: 'browserslist' },
   buf: { ids: ['buf', 'buf-gen'], defaultExtension: 'buf.yaml' },
   c: { ids: 'c', defaultExtension: 'c' },
   c_al: { ids: 'c-al', defaultExtension: 'cal' },

--- a/src/iconsManifest/supportedExtensions.ts
+++ b/src/iconsManifest/supportedExtensions.ts
@@ -786,6 +786,7 @@ export const extensions: IFileCollection = {
       icon: 'browserslist',
       extensions: ['.browserslistrc', 'browserslist'],
       filename: true,
+      languages: [languages.browserslist],
       format: FileFormat.svg,
     },
     {

--- a/src/models/language/languageCollection.ts
+++ b/src/models/language/languageCollection.ts
@@ -35,6 +35,7 @@ export interface ILanguageCollection extends INativeLanguageCollection {
   blitzbasic: ILanguage;
   bolt: ILanguage;
   bosque: ILanguage;
+  browserslist: ILanguage;
   buf: ILanguage;
   // eslint-disable-next-line camelcase
   c_al: ILanguage;


### PR DESCRIPTION
This adds support for the browserslist language registered by https://marketplace.visualstudio.com/items?itemName=webben.browserslist

The file names were already supported. The icon is now also visible in the language selector.

**Changes proposed:**

- [x] Add
- [ ] Delete
- [ ] Fix
- [ ] Prepare
