### PR TITLE
feat(icon): support the dockercompose language

### DIFF
--- a/src/iconsManifest/languages.ts
+++ b/src/iconsManifest/languages.ts
@@ -81,6 +81,7 @@ export const languages: ILanguageCollection = {
   django: { ids: ['django-html', 'django-txt'], defaultExtension: 'html' },
   diff: { ids: 'diff', defaultExtension: 'diff' },
   dlang: { ids: ['d', 'dscript', 'dml', 'diet'], defaultExtension: 'd' },
+  dockercompose: { ids: 'dockercompose', defaultExtension: 'yml' },
   dockerfile: { ids: 'dockerfile', defaultExtension: 'dockerfile' },
   doctex: { ids: 'doctex', defaultExtension: 'dtx' },
   dotenv: { ids: ['dotenv', 'env'], defaultExtension: 'env' },

--- a/src/iconsManifest/supportedExtensions.ts
+++ b/src/iconsManifest/supportedExtensions.ts
@@ -1399,7 +1399,7 @@ export const extensions: IFileCollection = {
       ],
       extensionsGlob: ['yaml', 'yml'],
       filename: true,
-      languages: [languages.dockerfile],
+      languages: [languages.dockercompose, languages.dockerfile],
       format: FileFormat.svg,
     },
     {
@@ -1416,7 +1416,7 @@ export const extensions: IFileCollection = {
       ],
       extensionsGlob: ['yaml', 'yml'],
       filename: true,
-      languages: [languages.dockerfile],
+      languages: [languages.dockercompose, languages.dockerfile],
       format: FileFormat.svg,
       disabled: true,
     },

--- a/src/models/language/languageCollection.ts
+++ b/src/models/language/languageCollection.ts
@@ -62,6 +62,7 @@ export interface ILanguageCollection extends INativeLanguageCollection {
   dhall: ILanguage;
   django: ILanguage;
   dlang: ILanguage;
+  dockercompose: ILanguage;
   doctex: ILanguage;
   dotenv: ILanguage;
   dotjs: ILanguage;


### PR DESCRIPTION
This adds support for the dockercompose language registered by https://marketplace.visualstudio.com/items?itemName=ms-azuretools.vscode-docker

The file names were already supported. The icon is now also visible in the language selector.

_Fixes #3124_

**Changes proposed:**

- [x] Add
- [ ] Delete
- [ ] Fix
- [ ] Prepare
