### PR TITLE
feat(icon): support the drawio language

### DIFF
--- a/src/iconsManifest/languages.ts
+++ b/src/iconsManifest/languages.ts
@@ -86,6 +86,7 @@ export const languages: ILanguageCollection = {
   dotenv: { ids: ['dotenv', 'env'], defaultExtension: 'env' },
   dotjs: { ids: 'dotjs', defaultExtension: 'dot' },
   doxygen: { ids: 'doxygen', defaultExtension: 'dox' },
+  drawio: { ids: 'drawio', defaultExtension: 'drawio' },
   drools: { ids: 'drools', defaultExtension: 'drl' },
   dustjs: { ids: 'dustjs', defaultExtension: 'dust' },
   dylanlang: { ids: ['dylan', 'dylan-lid'], defaultExtension: 'dylan' },

--- a/src/iconsManifest/supportedExtensions.ts
+++ b/src/iconsManifest/supportedExtensions.ts
@@ -1470,6 +1470,7 @@ export const extensions: IFileCollection = {
       extensions: ['drawio', 'dio'],
       filenamesGlob: ['.drawio', '.dio'],
       extensionsGlob: ['png', 'svg'],
+      languages: [languages.drawio],
       format: FileFormat.svg,
     },
     {

--- a/src/models/language/languageCollection.ts
+++ b/src/models/language/languageCollection.ts
@@ -66,6 +66,7 @@ export interface ILanguageCollection extends INativeLanguageCollection {
   dotenv: ILanguage;
   dotjs: ILanguage;
   doxygen: ILanguage;
+  drawio: ILanguage;
   drools: ILanguage;
   dustjs: ILanguage;
   dylanlang: ILanguage;


### PR DESCRIPTION
This adds support for the drawio language registered by https://marketplace.visualstudio.com/items?itemName=hediet.vscode-drawio

The file names were already supported. The icon is now also visible in the language selector.

**Changes proposed:**

- [x] Add
- [ ] Delete
- [ ] Fix
- [ ] Prepare
