### PR TITLE
feat(icon): support the editorconfig language

### DIFF
--- a/src/iconsManifest/languages.ts
+++ b/src/iconsManifest/languages.ts
@@ -91,6 +91,7 @@ export const languages: ILanguageCollection = {
   dylanlang: { ids: ['dylan', 'dylan-lid'], defaultExtension: 'dylan' },
   earthfile: { ids: 'earthfile', defaultExtension: 'earthfile' },
   edge: { ids: 'edge', defaultExtension: 'edge' },
+  editorconfig: { ids: 'editorconfig', defaultExtension: 'editorconfig' },
   eex: { ids: ['eex', 'html-eex'], defaultExtension: 'eex' },
   elastic: { ids: 'es', defaultExtension: 'es' },
   elixir: { ids: 'elixir', defaultExtension: 'ex' },

--- a/src/iconsManifest/supportedExtensions.ts
+++ b/src/iconsManifest/supportedExtensions.ts
@@ -1514,6 +1514,7 @@ export const extensions: IFileCollection = {
       icon: 'editorconfig',
       extensions: ['.editorconfig'],
       filename: true,
+      languages: [languages.editorconfig],
       format: FileFormat.svg,
     },
     {

--- a/src/models/language/languageCollection.ts
+++ b/src/models/language/languageCollection.ts
@@ -71,6 +71,7 @@ export interface ILanguageCollection extends INativeLanguageCollection {
   dylanlang: ILanguage;
   earthfile: ILanguage;
   edge: ILanguage;
+  editorconfig: ILanguage;
   eex: ILanguage;
   elastic: ILanguage;
   elixir: ILanguage;


### PR DESCRIPTION
This adds support for the editorconfig language registered by https://marketplace.visualstudio.com/items?itemName=EditorConfig.EditorConfig

The file names were already supported. The icon is now also visible in the language selector.

**Changes proposed:**

- [x] Add
- [ ] Delete
- [ ] Fix
- [ ] Prepare
