### PR TITLE
feat(icon): support the sass language

### DIFF
--- a/src/iconsManifest/languages.ts
+++ b/src/iconsManifest/languages.ts
@@ -294,6 +294,7 @@ export const languages: ILanguageCollection = {
   rust: { ids: 'rust', defaultExtension: 'rs' },
   san: { ids: 'san', defaultExtension: 'san' },
   sas: { ids: 'SAS', defaultExtension: 'sas' },
+  sass: { ids: ['sass', 'sass.hover'], defaultExtension: 'sass' },
   sbt: { ids: 'sbt', defaultExtension: 'sbt' },
   scad: { ids: 'scad', defaultExtension: 'scad' },
   scala: { ids: 'scala', defaultExtension: 'scala' },

--- a/src/iconsManifest/supportedExtensions.ts
+++ b/src/iconsManifest/supportedExtensions.ts
@@ -4125,7 +4125,12 @@ export const extensions: IFileCollection = {
       languages: [languages.sas],
       format: FileFormat.svg,
     },
-    { icon: 'sass', extensions: ['sass'], format: FileFormat.svg },
+    {
+      icon: 'sass',
+      extensions: ['sass'],
+      languages: [languages.sass],
+      format: FileFormat.svg,
+    },
     {
       icon: 'sbt',
       extensions: [],

--- a/src/models/language/languageCollection.ts
+++ b/src/models/language/languageCollection.ts
@@ -198,6 +198,7 @@ export interface ILanguageCollection extends INativeLanguageCollection {
   robot: ILanguage;
   san: ILanguage;
   sas: ILanguage;
+  sass: ILanguage;
   sbt: ILanguage;
   scad: ILanguage;
   scala: ILanguage;


### PR DESCRIPTION
This adds support for the sass and sass.hover languages registered by https://marketplace.visualstudio.com/items?itemName=Syler.sass-indented

The file names were already supported. The icon is now also visible in the language selector.

**Changes proposed:**

- [x] Add
- [ ] Delete
- [ ] Fix
- [ ] Prepare
