### PR TITLE
feat(icon): support the po language

### DIFF
--- a/src/iconsManifest/languages.ts
+++ b/src/iconsManifest/languages.ts
@@ -259,6 +259,7 @@ export const languages: ILanguageCollection = {
     defaultExtension: 'dbgasm',
   },
   plsql: { ids: ['plsql', 'oracle', 'oraclesql'], defaultExtension: 'ddl' },
+  po: { ids: 'po', defaultExtension: 'po' },
   polymer: { ids: 'polymer', defaultExtension: 'polymer' },
   pony: { ids: 'pony', defaultExtension: 'pony' },
   postcss: { ids: 'postcss', defaultExtension: 'pcss' },

--- a/src/iconsManifest/supportedExtensions.ts
+++ b/src/iconsManifest/supportedExtensions.ts
@@ -3531,7 +3531,12 @@ export const extensions: IFileCollection = {
       filename: true,
       format: FileFormat.svg,
     },
-    { icon: 'poedit', extensions: ['po', 'mo'], format: FileFormat.svg },
+    {
+      icon: 'poedit',
+      extensions: ['po', 'mo'],
+      languages: [languages.po],
+      format: FileFormat.svg,
+    },
     {
       icon: 'poetry',
       extensions: [],

--- a/src/models/language/languageCollection.ts
+++ b/src/models/language/languageCollection.ts
@@ -171,6 +171,7 @@ export interface ILanguageCollection extends INativeLanguageCollection {
   pip: ILanguage;
   platformio: ILanguage;
   plsql: ILanguage;
+  po: ILanguage;
   polymer: ILanguage;
   pony: ILanguage;
   postcss: ILanguage;


### PR DESCRIPTION
This adds support for the browserslist language registered by https://marketplace.visualstudio.com/items?itemName=mrorz.language-gettext

The file names were already supported. The icon is now also visible in the language selector.

**Changes proposed:**

- [x] Add
- [ ] Delete
- [ ] Fix
- [ ] Prepare
