### PR TITLE
feat(icon): support the csv language

### DIFF
--- a/src/iconsManifest/languages.ts
+++ b/src/iconsManifest/languages.ts
@@ -72,6 +72,17 @@ export const languages: ILanguageCollection = {
   crystal: { ids: 'crystal', defaultExtension: 'cr' },
   csharp: { ids: 'csharp', defaultExtension: 'cs' },
   css: { ids: 'css', defaultExtension: 'css' },
+  csv: {
+    ids: [
+      'csv',
+      'csv (pipe)',
+      'csv (semicolon)',
+      'csv (whitespace)',
+      'dynamic csv',
+      'tsv',
+    ],
+    defaultExtension: 'csv',
+  },
   cucumber: { ids: 'feature', defaultExtension: 'feature' },
   cuda: { ids: ['cuda', 'cuda-cpp'], defaultExtension: 'cu' },
   cython: { ids: 'cython', defaultExtension: 'pyx' },

--- a/src/iconsManifest/supportedExtensions.ts
+++ b/src/iconsManifest/supportedExtensions.ts
@@ -4595,7 +4595,7 @@ export const extensions: IFileCollection = {
     {
       icon: 'text',
       extensions: ['csv', 'tsv'],
-      languages: [languages.plaintext],
+      languages: [languages.csv, languages.plaintext],
       format: FileFormat.svg,
     },
     {

--- a/src/models/language/nativeLanguageCollection.ts
+++ b/src/models/language/nativeLanguageCollection.ts
@@ -9,6 +9,7 @@ export interface INativeLanguageCollection {
   coffeescript: ILanguage;
   cpp: ILanguage;
   css: ILanguage;
+  csv: ILanguage;
   diff: ILanguage;
   dockerfile: ILanguage;
   fsharp: ILanguage;


### PR DESCRIPTION
This adds support for the csv language registered by https://marketplace.visualstudio.com/items?itemName=mechatroner.rainbow-csv

The file names were already supported. The icon is now also visible in the language selector.

**Changes proposed:**

- [x] Add
- [ ] Delete
- [ ] Fix
- [ ] Prepare
