### PR TITLE
feat(icon): support the svg language

### DIFF
--- a/src/iconsManifest/languages.ts
+++ b/src/iconsManifest/languages.ts
@@ -332,6 +332,7 @@ export const languages: ILanguageCollection = {
   styled: { ids: 'source.css.styled', defaultExtension: 'styled' },
   stylus: { ids: 'stylus', defaultExtension: 'styl' },
   svelte: { ids: 'svelte', defaultExtension: 'svelte' },
+  svg: { ids: 'svg', defaultExtension: 'svg' },
   swagger: { ids: ['Swagger', 'swagger'], defaultExtension: 'swagger' },
   swift: { ids: 'swift', defaultExtension: 'swift' },
   swig: { ids: 'swig', defaultExtension: 'swig' },

--- a/src/iconsManifest/supportedExtensions.ts
+++ b/src/iconsManifest/supportedExtensions.ts
@@ -4451,7 +4451,12 @@ export const extensions: IFileCollection = {
       filename: true,
       format: FileFormat.svg,
     },
-    { icon: 'svg', extensions: ['svg'], format: FileFormat.svg },
+    {
+      icon: 'svg',
+      extensions: ['svg'],
+      languages: [languages.svg],
+      format: FileFormat.svg,
+    },
     {
       icon: 'swagger',
       extensions: [],

--- a/src/models/language/languageCollection.ts
+++ b/src/models/language/languageCollection.ts
@@ -226,6 +226,7 @@ export interface ILanguageCollection extends INativeLanguageCollection {
   styled: ILanguage;
   stylus: ILanguage;
   svelte: ILanguage;
+  svg: ILanguage;
   swagger: ILanguage;
   swig: ILanguage;
   systemd: ILanguage;


### PR DESCRIPTION
This adds support for the svg language registered by https://marketplace.visualstudio.com/items?itemName=jock.svg

The file names were already supported. The icon is now also visible in the language selector.

**Changes proposed:**

- [x] Add
- [ ] Delete
- [ ] Fix
- [ ] Prepare
