### PR TITLE
feat(icon): support the org language

### DIFF
--- a/src/iconsManifest/languages.ts
+++ b/src/iconsManifest/languages.ts
@@ -239,6 +239,7 @@ export const languages: ILanguageCollection = {
   ogone: { ids: 'ogone', defaultExtension: 'o3' },
   openEdge: { ids: 'abl', defaultExtension: 'w' },
   openHAB: { ids: 'openhab', defaultExtension: 'things' },
+  org: { ids: 'org', defaultExtension: 'org' },
   pascal: { ids: ['pascal', 'objectpascal'], defaultExtension: 'pas' },
   pddl: { ids: 'pddl', defaultExtension: 'pddl' },
   pddlplan: { ids: 'plan', defaultExtension: 'plan' },

--- a/src/iconsManifest/supportedExtensions.ts
+++ b/src/iconsManifest/supportedExtensions.ts
@@ -3293,7 +3293,12 @@ export const extensions: IFileCollection = {
       light: true,
       format: FileFormat.svg,
     },
-    { icon: 'org', extensions: ['org'], format: FileFormat.svg },
+    {
+      icon: 'org',
+      extensions: ['org'],
+      languages: [languages.org],
+      format: FileFormat.svg,
+    },
     {
       icon: 'outlook',
       extensions: ['pst', 'bcmx', 'otm', 'msg', 'oft'],

--- a/src/models/language/languageCollection.ts
+++ b/src/models/language/languageCollection.ts
@@ -162,6 +162,7 @@ export interface ILanguageCollection extends INativeLanguageCollection {
   ogone: ILanguage;
   openEdge: ILanguage;
   openHAB: ILanguage;
+  org: ILanguage;
   pascal: ILanguage;
   pddl: ILanguage;
   pddlplan: ILanguage;


### PR DESCRIPTION
This adds support for the org language registered by https://marketplace.visualstudio.com/items?itemName=tootone.org-mode

The file names were already supported. The icon is now also visible in the language selector.

**Changes proposed:**

- [x] Add
- [ ] Delete
- [ ] Fix
- [ ] Prepare
