### PR TITLE
feat(icon): support the yarnlock language

### DIFF
--- a/src/iconsManifest/languages.ts
+++ b/src/iconsManifest/languages.ts
@@ -383,5 +383,6 @@ export const languages: ILanguageCollection = {
   yacc: { ids: 'yacc', defaultExtension: 'bison' },
   yaml: { ids: 'yaml', defaultExtension: 'yaml' },
   yang: { ids: 'yang', defaultExtension: 'yang' },
+  yarnlock: { ids: 'yarnlock', defaultExtension: 'lock' },
   zig: { ids: 'zig', defaultExtension: 'zig' },
 };

--- a/src/iconsManifest/supportedExtensions.ts
+++ b/src/iconsManifest/supportedExtensions.ts
@@ -5298,6 +5298,7 @@ export const extensions: IFileCollection = {
         '.yarnignore',
       ],
       filename: true,
+      languages: [languages.yarnlock],
       format: FileFormat.svg,
     },
     {

--- a/src/models/language/nativeLanguageCollection.ts
+++ b/src/models/language/nativeLanguageCollection.ts
@@ -55,4 +55,5 @@ export interface INativeLanguageCollection {
   xml: ILanguage;
   xsl: ILanguage;
   yaml: ILanguage;
+  yarnlock: ILanguage;
 }


### PR DESCRIPTION
This adds support for the yarnlock language registered by https://marketplace.visualstudio.com/items?itemName=mariusschulz.yarn-lock-syntax

The file names were already supported. The icon is now also visible in the language selector.

**Changes proposed:**

- [x] Add
- [ ] Delete
- [ ] Fix
- [ ] Prepare
