### PR TITLE
feat(icon): support the sln language

### DIFF
--- a/src/iconsManifest/languages.ts
+++ b/src/iconsManifest/languages.ts
@@ -305,6 +305,7 @@ export const languages: ILanguageCollection = {
   slang: { ids: 'slang', defaultExtension: 'slang' },
   slice: { ids: ['slice'], defaultExtension: 'ice' },
   slim: { ids: ['slim'], defaultExtension: 'slim' },
+  sln: { ids: 'sln', defaultExtension: 'sln' },
   silverstripe: { ids: 'silverstripe', defaultExtension: 'ss' },
   sino: { ids: 'sino', defaultExtension: 'sn' },
   skipper: { ids: ['eskip'], defaultExtension: 'eskip' },

--- a/src/iconsManifest/supportedExtensions.ts
+++ b/src/iconsManifest/supportedExtensions.ts
@@ -4247,7 +4247,12 @@ export const extensions: IFileCollection = {
       languages: [languages.slim],
       format: FileFormat.svg,
     },
-    { icon: 'sln', extensions: ['sln'], format: FileFormat.svg },
+    {
+      icon: 'sln',
+      extensions: ['sln'],
+      languages: [languages.sln],
+      format: FileFormat.svg,
+    },
     {
       icon: 'sln2',
       extensions: ['sln'],

--- a/src/models/language/languageCollection.ts
+++ b/src/models/language/languageCollection.ts
@@ -206,6 +206,7 @@ export interface ILanguageCollection extends INativeLanguageCollection {
   slang: ILanguage;
   slice: ILanguage;
   slim: ILanguage;
+  sln: ILanguage;
   silverstripe: ILanguage;
   sino: ILanguage;
   skipper: ILanguage;


### PR DESCRIPTION
This adds support for the sln language registered by https://marketplace.visualstudio.com/items?itemName=logerfo.sln-support

The file names were already supported. The icon is now also visible in the language selector.

**Changes proposed:**

- [x] Add
- [ ] Delete
- [ ] Fix
- [ ] Prepare
