### PR TITLE
feat(icon): support the excel language

### DIFF
--- a/src/iconsManifest/languages.ts
+++ b/src/iconsManifest/languages.ts
@@ -98,6 +98,7 @@ export const languages: ILanguageCollection = {
   erb: { ids: ['erb', 'html.erb'], defaultExtension: 'erb' },
   erlang: { ids: 'erlang', defaultExtension: 'erl' },
   esphome: { ids: 'esphome', defaultExtension: 'yaml' },
+  excel: { ids: 'excel', defaultExtension: 'xlsx' },
   falcon: { ids: 'falcon', defaultExtension: 'falcon' },
   fauna: { ids: 'fql', defaultExtension: 'fql' },
   fortran: {

--- a/src/iconsManifest/supportedExtensions.ts
+++ b/src/iconsManifest/supportedExtensions.ts
@@ -1666,11 +1666,13 @@ export const extensions: IFileCollection = {
     {
       icon: 'excel',
       extensions: ['xls', 'xlsx', 'xlsm', 'ods', 'fods', 'xlsb'],
+      languages: [languages.excel],
       format: FileFormat.svg,
     },
     {
       icon: 'excel2',
       extensions: ['xls', 'xlsx', 'xlsm', 'ods', 'fods', 'xlsb'],
+      languages: [languages.excel],
       format: FileFormat.svg,
       disabled: true,
     },

--- a/src/models/language/languageCollection.ts
+++ b/src/models/language/languageCollection.ts
@@ -78,6 +78,7 @@ export interface ILanguageCollection extends INativeLanguageCollection {
   erb: ILanguage;
   erlang: ILanguage;
   esphome: ILanguage;
+  excel: ILanguage;
   falcon: ILanguage;
   fauna: ILanguage;
   fortran: ILanguage;


### PR DESCRIPTION
This adds support for the excel language registered by https://marketplace.visualstudio.com/items?itemName=GrapeCity.gc-excelviewer

The file names were already supported. The icon is now also visible in the language selector.

**Changes proposed:**

- [x] Add
- [ ] Delete
- [ ] Fix
- [ ] Prepare
