### PR TITLE
feat(icon): support the go.mod and go.work languages

### DIFF
--- a/src/iconsManifest/languages.ts
+++ b/src/iconsManifest/languages.ts
@@ -124,6 +124,8 @@ export const languages: ILanguageCollection = {
   glyphs: { ids: 'glyphs', defaultExtension: 'glyphs' },
   gnuplot: { ids: 'gnuplot', defaultExtension: 'gp' },
   go: { ids: 'go', defaultExtension: 'go' },
+  gomod: { ids: 'go.mod', defaultExtension: 'mod' },
+  gowork: { ids: 'go.work', defaultExtension: 'work' },
   goctl: { ids: 'goctl', defaultExtension: 'api' },
   gdscript: { ids: 'gdscript', defaultExtension: 'gd' },
   grain: { ids: 'grain', defaultExtension: 'gr' },

--- a/src/iconsManifest/supportedExtensions.ts
+++ b/src/iconsManifest/supportedExtensions.ts
@@ -1990,11 +1990,13 @@ export const extensions: IFileCollection = {
       extensions: ['go.sum', 'go.mod'],
       filename: true,
       format: FileFormat.svg,
+      languages: [languages.gomod],
     },
     {
       icon: 'go_work',
       extensions: ['go.work', 'go.work.sum'],
       filename: true,
+      languages: [languages.gowork],
       format: FileFormat.svg,
     },
     {

--- a/src/models/language/languageCollection.ts
+++ b/src/models/language/languageCollection.ts
@@ -93,6 +93,8 @@ export interface ILanguageCollection extends INativeLanguageCollection {
   glsl: ILanguage;
   glyphs: ILanguage;
   gnuplot: ILanguage;
+  gomod: ILanguage;
+  gowork: ILanguage;
   grain: ILanguage;
   graphql: ILanguage;
   graphviz: ILanguage;


### PR DESCRIPTION
This adds support for the go.mod and go.work languages registered by https://marketplace.visualstudio.com/items?itemName=golang.Go

The file names were already supported. The icon is now also visible in the language selector.

There is also the related go.sum language, but the matching filename is sometimes associated with the go.mod icon, and sometimes with the go.work icon.

**Changes proposed:**

- [x] Add
- [ ] Delete
- [ ] Fix
- [ ] Prepare
