### PR TITLE
feat(icon): support the code-text-binary language

### DIFF
--- a/src/iconsManifest/languages.ts
+++ b/src/iconsManifest/languages.ts
@@ -44,6 +44,7 @@ export const languages: ILanguageCollection = {
   bicep: { ids: 'bicep', defaultExtension: 'bicep' },
   bibtex: { ids: 'bibtex', defaultExtension: 'bib' },
   biml: { ids: 'biml', defaultExtension: 'biml' },
+  binary: { ids: 'code-text-binary', defaultExtension: 'bin' },
   blade: { ids: ['blade', 'laravel-blade'], defaultExtension: 'blade.php' },
   blitzbasic: { ids: ['blitzbasic'], defaultExtension: 'blitzbasic' },
   bolt: { ids: 'bolt', defaultExtension: 'bolt' },

--- a/src/iconsManifest/supportedExtensions.ts
+++ b/src/iconsManifest/supportedExtensions.ts
@@ -741,6 +741,7 @@ export const extensions: IFileCollection = {
         'scptd',
         'so',
       ],
+      languages: [languages.binary],
       format: FileFormat.svg,
     },
     {

--- a/src/models/language/languageCollection.ts
+++ b/src/models/language/languageCollection.ts
@@ -32,6 +32,7 @@ export interface ILanguageCollection extends INativeLanguageCollection {
   befunge: ILanguage;
   bibtex: ILanguage;
   biml: ILanguage;
+  binary: ILanguage;
   blade: ILanguage;
   blitzbasic: ILanguage;
   bolt: ILanguage;


### PR DESCRIPTION
This adds support for the builtin `code-text-binary` language, which is used to represent binary files in VS Code.

**Changes proposed:**

- [x] Add
- [ ] Delete
- [ ] Fix
- [ ] Prepare
