### PR TITLE
chore: update to Node.js 16.14.2 in wpil workflow

### DIFF
--- a/.github/workflows/wpil.yml
+++ b/.github/workflows/wpil.yml
@@ -21,7 +21,7 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
 
       - name: Upgrade npm
-        run: npm i -g npm@latest
+        run: npm i -g npm@9
 
       - name: Cloning repository
         uses: actions/checkout@v3

--- a/.github/workflows/wpil.yml
+++ b/.github/workflows/wpil.yml
@@ -1,7 +1,7 @@
 name: Update Wiki Page Icons List
 
 env:
-  NODE_VERSION: 14.21.3
+  NODE_VERSION: 16.14.2
 
 on:
   push:
@@ -20,9 +20,6 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
 
-      - name: Upgrade npm
-        run: npm i -g npm@latest
-
       - name: Cloning repository
         uses: actions/checkout@v3
         with:
@@ -39,4 +36,3 @@ jobs:
         run: npx --yes vscode-icons/wpilgenerator
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-

--- a/.github/workflows/wpil.yml
+++ b/.github/workflows/wpil.yml
@@ -1,7 +1,7 @@
 name: Update Wiki Page Icons List
 
 env:
-  NODE_VERSION: 16.14.2
+  NODE_VERSION: 14.21.3
 
 on:
   push:
@@ -20,6 +20,9 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
 
+      - name: Upgrade npm
+        run: npm i -g npm@latest
+
       - name: Cloning repository
         uses: actions/checkout@v3
         with:
@@ -36,3 +39,4 @@ jobs:
         run: npx --yes vscode-icons/wpilgenerator
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+


### PR DESCRIPTION
Before, Node.js 14 was used. A step would update npm to the latest version. However, npm 10, the latest version of npm at the moment of writing, doesn’t support Node.js 14.

Instead of using such an old version of Node.js, the Node.js version was updated to 16.14.2. This is already EOL, so ideally an even more recent version would be used. The npm shipped with this Node.js version is probably recent enough, so the npm update step was removed.