### PR TITLE
feat(icon): use the gnu icon for autoconf files

### DIFF
--- a/src/iconsManifest/languages.ts
+++ b/src/iconsManifest/languages.ts
@@ -30,6 +30,7 @@ export const languages: ILanguageCollection = {
   ats: { ids: ['ats'], defaultExtension: 'ats' },
   autohotkey: { ids: 'ahk', defaultExtension: 'ahk' },
   autoit: { ids: 'autoit', defaultExtension: 'au3' },
+  automake: { ids: 'automake', defaultExtension: 'am' },
   avro: { ids: 'avro', defaultExtension: 'avcs' },
   azcli: { ids: 'azcli', defaultExtension: 'azcli' },
   azurepipelines: {
@@ -241,7 +242,8 @@ export const languages: ILanguageCollection = {
   lolcode: { ids: 'lolcode', defaultExtension: 'lol' },
   lsl: { ids: 'lsl', defaultExtension: 'lsl' },
   lua: { ids: 'lua', defaultExtension: 'lua' },
-  makefile: { ids: 'makefile', defaultExtension: 'mk' },
+  m4: { ids: 'm4', defaultExtension: 'm4' },
+  makefile: { ids: ['makefile', 'makefile2'], defaultExtension: 'mk' },
   markdown: { ids: 'markdown', defaultExtension: 'md' },
   marko: { ids: 'marko', defaultExtension: 'marko' },
   matlab: { ids: 'matlab', defaultExtension: 'mat' },

--- a/src/iconsManifest/supportedExtensions.ts
+++ b/src/iconsManifest/supportedExtensions.ts
@@ -2008,8 +2008,8 @@ export const extensions: IFileCollection = {
     },
     {
       icon: 'gnu',
-      extensions: ['ld', 'makefile'],
-      languages: [languages.makefile],
+      extensions: ['am', 'ld', 'm4', 'makefile'],
+      languages: [languages.automake, languages.m4, languages.makefile],
       format: FileFormat.svg,
     },
     {

--- a/src/models/language/languageCollection.ts
+++ b/src/models/language/languageCollection.ts
@@ -22,6 +22,7 @@ export interface ILanguageCollection extends INativeLanguageCollection {
   assembly: ILanguage;
   autohotkey: ILanguage;
   autoit: ILanguage;
+  automake: ILanguage;
   avro: ILanguage;
   azcli: ILanguage;
   azurepipelines: ILanguage;
@@ -148,6 +149,7 @@ export interface ILanguageCollection extends INativeLanguageCollection {
   log: ILanguage;
   lolcode: ILanguage;
   lsl: ILanguage;
+  m4: ILanguage;
   marko: ILanguage;
   matlab: ILanguage;
   maxscript: ILanguage;


### PR DESCRIPTION
This registers the autoconf `m4`, `automake`, and `makefile2` languages. These are all defined by
https://marketplace.visualstudio.com/items?itemName=maelvalais.autoconf.

Since these are all GNU tools, the `gnu` icon was used for all of them.

**Changes proposed:**

- [x] Add
- [ ] Delete
- [ ] Fix
- [ ] Prepare
