### PR TITLE
feat: update stylelint extensions, add .mjs

### DIFF
--- a/src/iconsManifest/supportedExtensions.ts
+++ b/src/iconsManifest/supportedExtensions.ts
@@ -4502,7 +4502,7 @@ export const extensions: IFileCollection = {
       icon: 'stylelint',
       extensions: ['.stylelintrc', '.stylelintignore', '.stylelintcache'],
       filenamesGlob: ['stylelint.config', '.stylelintrc'],
-      extensionsGlob: ['js', 'json', 'yaml', 'yml', 'ts', 'cjs'],
+      extensionsGlob: ['js', 'json', 'yaml', 'yml', 'ts', 'cjs', 'mjs'],
       light: true,
       filename: true,
       format: FileFormat.svg,


### PR DESCRIPTION
<!-- markdownlint-disable MD041-->

<!-- Please first read how to submit a pull request, if you haven't already done so.
https://github.com/vscode-icons/vscode-icons/wiki/PullRequest -->

Stylelint has supported `.mjs` config file. This PR updates stylelint extensions by adding `.mjs`.

[stylelint.io/user-guide/configure](https://stylelint.io/user-guide/configure/)

<img width="1149" alt="image" src="https://github.com/vscode-icons/vscode-icons/assets/31850793/de482d6d-16c9-4856-99e0-b051564ff107">

**Changes proposed:**

- [x] Add
- [ ] Delete
- [ ] Fix
- [ ] Prepare
