### PR TITLE
feat(icon): use npm icon for .package-lock.json

### DIFF
--- a/src/iconsManifest/supportedExtensions.ts
+++ b/src/iconsManifest/supportedExtensions.ts
@@ -3241,6 +3241,7 @@ export const extensions: IFileCollection = {
       extensions: [
         '.npmignore',
         '.npmrc',
+        '.package-lock.json',
         'package.json',
         'package-lock.json',
         'npm-shrinkwrap.json',


### PR DESCRIPTION
The `.package-lock.json` file is a version 3 lockfile that npm writes to the `node_modules` directory.

**Changes proposed:**

- [x] Add
- [ ] Delete
- [ ] Fix
- [ ] Prepare
