### PR TITLE
feat(icon): register the vim-help and vim-snippet languages

### DIFF
--- a/src/iconsManifest/languages.ts
+++ b/src/iconsManifest/languages.ts
@@ -280,7 +280,7 @@ export const languages: ILanguageCollection = {
   php: { ids: 'php', defaultExtension: 'php' },
   pine: { ids: ['pine', 'pinescript'], defaultExtension: 'pine' },
   pip: { ids: 'pip-requirements', defaultExtension: 'requirements.txt' },
-  plaintext: { ids: 'plaintext', defaultExtension: 'txt' },
+  plaintext: { ids: ['plaintext', 'vim-help'], defaultExtension: 'txt' },
   platformio: {
     ids: [
       'platformio-debug.disassembly',
@@ -402,7 +402,7 @@ export const languages: ILanguageCollection = {
   vento: { ids: 'vento', defaultExtension: 'vto' },
   verilog: { ids: 'verilog', defaultExtension: 'v' },
   vhdl: { ids: 'vhdl', defaultExtension: 'vhdl' },
-  viml: { ids: 'viml', defaultExtension: 'vim' },
+  viml: { ids: ['viml', 'vim-snippet'], defaultExtension: 'vim' },
   vlang: { ids: 'v', defaultExtension: 'v' },
   volt: { ids: 'volt', defaultExtension: 'volt' },
   vue: { ids: 'vue', defaultExtension: 'vue' },


### PR DESCRIPTION
Both the `vim-help` and the `vim-snippet` languages are registered by https://marketplace.visualstudio.com/items?itemName=XadillaX.viml.

Because `vim-help` applies to `.txt` files matching a pattern, I thought it makes sense to treat them the same as `plaintext`. `vim-snippet` files uses extensions that may conflict with others, so I just added the language ID to the `viml` language.

This extension also registers the `vim-markdown` extension, which it shouldn’t (https://github.com/XadillaX/vscode-language-viml/pull/67).

This extension also registers the [`vroom`](https://github.com/google/vroom) language. I could only find a PNG icon for this. It’s just text with some colors, but I don’t know the font.

**Changes proposed:**

- [x] Add
- [ ] Delete
- [ ] Fix
- [ ] Prepare
