### PR TITLE
Fix wrong reference pointer in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Choose the icon you prefer for any particular file extension.
 
 You don't see the icon you like...? No worries, we got you covered. This link will show you how you can use your own custom icon!
 
-[Learn more...](https://github.com/vscode-icons/vscode-icons/wiki/Configuration)
+[Learn more...](https://github.com/vscode-icons/vscode-icons/wiki/Custom)
 
 ### Project Auto Detection
 


### PR DESCRIPTION
_**Fixes #3469**_

**Changes proposed:**
- [x] Fix

#### Description
Change the link reference pointer in the [Bring your own icons](https://github.com/vscode-icons/vscode-icons?tab=readme-ov-file#bring-your-own-icons) section of the[ README](https://github.com/vscode-icons/vscode-icons/blob/master/README.md) to the [correct document](https://github.com/vscode-icons/vscode-icons/wiki/custom) 

