### PR TITLE
Add shared extensions

### DIFF
--- a/src/iconsManifest/supportedFolders.ts
+++ b/src/iconsManifest/supportedFolders.ts
@@ -573,7 +573,14 @@ export const extensions: IFolderCollection = {
     },
     {
       icon: 'shared',
-      extensions: ['share', 'shared', '.share', '.shared'],
+      extensions: [
+        'share',
+        'shared',
+        '.share',
+        '.shared',
+        '__shared__',
+        '__share__',
+      ],
       format: FileFormat.svg,
     },
     {


### PR DESCRIPTION
This PR adds `__shared__` and `__share__` as aliases for the `shared` folder icon, similar to how the `tests` folder icon has the same support.

**Changes proposed:**

- [x] Add
- [ ] Delete
- [ ] Fix
- [ ] Prepare
