### PR TITLE
feat(icon): supported `.slnx` file

### DIFF
--- a/src/iconsManifest/supportedExtensions.ts
+++ b/src/iconsManifest/supportedExtensions.ts
@@ -4356,13 +4356,13 @@ export const extensions: IFileCollection = {
     },
     {
       icon: 'sln',
-      extensions: ['sln'],
+      extensions: ['sln', slnx'],
       languages: [languages.sln],
       format: FileFormat.svg,
     },
     {
       icon: 'sln2',
-      extensions: ['sln'],
+      extensions: ['sln', slnx'],
       format: FileFormat.svg,
       disabled: true,
     },

--- a/src/iconsManifest/supportedExtensions.ts
+++ b/src/iconsManifest/supportedExtensions.ts
@@ -4356,13 +4356,13 @@ export const extensions: IFileCollection = {
     },
     {
       icon: 'sln',
-      extensions: ['sln', slnx'],
+      extensions: ['sln', 'slnx'],
       languages: [languages.sln],
       format: FileFormat.svg,
     },
     {
       icon: 'sln2',
-      extensions: ['sln', slnx'],
+      extensions: ['sln', 'slnx'],
       format: FileFormat.svg,
       disabled: true,
     },


### PR DESCRIPTION
Microsoft began experimenting with the publishing of an XML-based solution format, and it has the extension `.slnx`.

reference: https://schwabencode.com/blog/2024/04/10/welcome-new-visual-studio-slnx-solution-file

<!-- markdownlint-disable MD041-->

<!-- Please first read how to submit a pull request, if you haven't already done so.
https://github.com/vscode-icons/vscode-icons/wiki/PullRequest -->

**Changes proposed:**

- [x] Add
- [ ] Delete
- [ ] Fix
- [ ] Prepare
