### PR TITLE
Added icon association for files with the .config extension

### DIFF
--- a/src/iconsManifest/supportedExtensions.ts
+++ b/src/iconsManifest/supportedExtensions.ts
@@ -1099,7 +1099,7 @@ export const extensions: IFileCollection = {
     },
     {
       icon: 'config',
-      extensions: ['plist'],
+      extensions: ['plist', 'config'],
       languages: [languages.properties, languages.springbootproperties],
       light: true,
       format: FileFormat.svg,


### PR DESCRIPTION
Added icon association for files with the .config extension. Icon: https://github.com/vscode-icons/vscode-icons/blob/master/icons/file_type_config.svg

**Changes proposed:**

- [x] Add
- [ ] Delete
- [ ] Fix
- [ ] Prepare
