### PR TITLE
Added icon association for files with the name azure-pipelines.yaml

### DIFF
--- a/src/iconsManifest/supportedExtensions.ts
+++ b/src/iconsManifest/supportedExtensions.ts
@@ -1099,7 +1099,7 @@ export const extensions: IFileCollection = {
     },
     {
       icon: 'config',
-      extensions: ['plist'],
+      extensions: ['plist', 'config'],
       languages: [languages.properties, languages.springbootproperties],
       light: true,
       format: FileFormat.svg,

--- a/src/iconsManifest/supportedExtensions.ts
+++ b/src/iconsManifest/supportedExtensions.ts
@@ -627,7 +627,7 @@ export const extensions: IFileCollection = {
     },
     {
       icon: 'azurepipelines',
-      extensions: ['azure-pipelines.yml', '.vsts-ci.yml'],
+      extensions: ['azure-pipelines.yml', '.vsts-ci.yml', 'azure-pipelines.yaml'],
       filename: true,
       languages: [languages.azurepipelines],
       format: FileFormat.svg,


### PR DESCRIPTION
Added icon association for files with the name azure-pipelines.yaml. Icon: https://github.com/vscode-icons/vscode-icons/blob/master/icons/file_type_azurepipelines.svg

- [x] Add
- [ ] Delete
- [ ] Fix
- [ ] Prepare
