### PR TITLE
chore: support `nuxt` file

### DIFF
--- a/src/iconsManifest/supportedExtensions.ts
+++ b/src/iconsManifest/supportedExtensions.ts
@@ -3392,7 +3392,7 @@ export const extensions: IFileCollection = {
     {
       icon: 'nuxt',
       extensions: ['.nuxtignore', '.nuxtrc'],
-      filenamesGlob: ['nuxt.config'],
+      filenamesGlob: ['nuxt.config', '.config/nuxt'],
       extensionsGlob: ['js', 'ts', 'mjs'],
       filename: true,
       format: FileFormat.svg,

--- a/src/iconsManifest/supportedExtensions.ts
+++ b/src/iconsManifest/supportedExtensions.ts
@@ -3392,7 +3392,7 @@ export const extensions: IFileCollection = {
     {
       icon: 'nuxt',
       extensions: ['.nuxtignore', '.nuxtrc'],
-      filenamesGlob: ['nuxt.config', '.config/nuxt'],
+      filenamesGlob: ['nuxt.config', 'nuxt'],
       extensionsGlob: ['js', 'ts', 'mjs'],
       filename: true,
       format: FileFormat.svg,


### PR DESCRIPTION
<!-- markdownlint-disable MD041-->

<!-- Please first read how to submit a pull request, if you haven't already done so.
https://github.com/vscode-icons/vscode-icons/wiki/PullRequest -->

Since Nuxt v3.10.1, a `.config` folder can be used to place its config file. This PR makes sure to watch that folder too.

### References
- https://github.com/nuxt/cli/pull/341
- https://github.com/nuxt/cli/releases/tag/v3.10.1

**Changes proposed:**

- [ ] Add
- [ ] Delete
- [x] Fix
- [ ] Prepare
