### PR TITLE
feat(icon): support the prototext language

### DIFF
--- a/src/iconsManifest/languages.ts
+++ b/src/iconsManifest/languages.ts
@@ -316,7 +316,10 @@ export const languages = {
     ids: ['java-properties', 'properties'],
     defaultExtension: 'properties',
   },
-  protobuf: { ids: ['proto3', 'proto'], defaultExtension: 'proto' },
+  protobuf: {
+    ids: ['proto3', 'proto', 'prototext'],
+    defaultExtension: 'proto',
+  },
   pug: { ids: 'jade', defaultExtension: 'pug' },
   puppet: { ids: 'puppet', defaultExtension: 'pp' },
   purescript: { ids: 'purescript', defaultExtension: 'purs' },


### PR DESCRIPTION
The `prototext` language ID is now treated the same as `proto` and `proto3`. It’s registered by
https://marketplace.visualstudio.com/items?itemName=pbkit.vscode-pbkit as well as
https://marketplace.visualstudio.com/items?itemName=dmitry-korobchenko.prototxt

**Changes proposed:**

- [x] Add
- [ ] Delete
- [ ] Fix
- [ ] Prepare
