### PR TITLE
Added azure-pipelines.yaml extension binding

### DIFF
--- a/src/iconsManifest/supportedExtensions.ts
+++ b/src/iconsManifest/supportedExtensions.ts
@@ -627,7 +627,7 @@ export const extensions: IFileCollection = {
     },
     {
       icon: 'azurepipelines',
-      extensions: ['azure-pipelines.yml', '.vsts-ci.yml'],
+      extensions: ['azure-pipelines.yml', '.vsts-ci.yml', 'azure-pipelines.yaml'],
       filename: true,
       languages: [languages.azurepipelines],
       format: FileFormat.svg,


### PR DESCRIPTION
Added filename association for azure-pipelines.yaml. Currently there is only association for azure-pipelines.yml
Icon: https://raw.githubusercontent.com/vscode-icons/vscode-icons/89a95757aed9a585f6f5256baa96f989b89a061c/icons/file_type_azurepipelines.svg

- [x] Add
- [ ] Delete
- [ ] Fix
- [ ] Prepare
