### PR TITLE
feat(icon): support `next.config.ts`

### DIFF
--- a/src/iconsManifest/supportedExtensions.ts
+++ b/src/iconsManifest/supportedExtensions.ts
@@ -3272,7 +3272,12 @@ export const extensions: IFileCollection = {
     },
     {
       icon: 'next',
-      extensions: ['next.config.js', 'next.config.cjs', 'next.config.mjs'],
+      extensions: [
+        'next.config.js',
+        'next.config.cjs',
+        'next.config.mjs',
+        'next.config.ts',
+      ],
       filename: true,
       light: true,
       format: FileFormat.svg,


### PR DESCRIPTION
**Changes proposed:**

- [x] Add

[According to the Next.js developers](https://github.com/vercel/next.js/discussions/35969#discussioncomment-10005034), support for the `next.config.ts` configuration file has been added, so I added support for this filename.