### PR TITLE
feat: Association added for config extension

### DIFF
--- a/src/iconsManifest/supportedExtensions.ts
+++ b/src/iconsManifest/supportedExtensions.ts
@@ -1099,7 +1099,7 @@ export const extensions: IFileCollection = {
     },
     {
       icon: 'config',
-      extensions: ['plist'],
+      extensions: ['plist', 'config'],
       languages: [languages.properties, languages.springbootproperties],
       light: true,
       format: FileFormat.svg,


### PR DESCRIPTION
Association added for config extension, icon: https://raw.githubusercontent.com/vscode-icons/vscode-icons/89a95757aed9a585f6f5256baa96f989b89a061c/icons/file_type_config.svg

**Changes proposed:**

- [x] Add
- [ ] Delete
- [ ] Fix
- [ ] Prepare
