### PR TITLE
feat(icon): use lighthouse icon for budget(s).json

### DIFF
--- a/src/iconsManifest/supportedExtensions.ts
+++ b/src/iconsManifest/supportedExtensions.ts
@@ -2782,7 +2782,7 @@ export const extensions: IFileCollection = {
     },
     {
       icon: 'lighthouse',
-      extensions: [],
+      extensions: ['budget.json', 'budgets.json'],
       filenamesGlob: ['.lighthouserc'],
       extensionsGlob: ['cjs', 'js', 'json', 'yaml', 'yml'],
       filename: true,


### PR DESCRIPTION
Both `budget.json` and `budgets.json` are used by Lighthouse CI. Although there’s no default value, it’s a common convention to use one of these file names. See
https://github.com/GoogleChrome/lighthouse-ci/blob/main/docs/configuration.md

<!-- markdownlint-disable MD041-->

**Changes proposed:**

- [x] Add
- [ ] Delete
- [ ] Fix
- [ ] Prepare
