### PR TITLE
feat: Added association for protobuf icon

### DIFF
--- a/src/iconsManifest/supportedExtensions.ts
+++ b/src/iconsManifest/supportedExtensions.ts
@@ -3958,7 +3958,7 @@ export const extensions: IFileCollection = {
     },
     {
       icon: 'protobuf',
-      extensions: [],
+      extensions: ['proto'],
       languages: [languages.protobuf],
       format: FileFormat.svg,
     },


### PR DESCRIPTION
Added association for protobuf icon: https://raw.githubusercontent.com/vscode-icons/vscode-icons/89a95757aed9a585f6f5256baa96f989b89a061c/icons/file_type_protobuf.svg

**Changes proposed:**

- [x] Add
- [ ] Delete
- [ ] Fix
- [ ] Prepare
