### PR TITLE
Add '.yaml' as alternative supported extension for 'gitlab-ci.yml'

### DIFF
--- a/src/iconsManifest/supportedExtensions.ts
+++ b/src/iconsManifest/supportedExtensions.ts
@@ -2007,7 +2007,7 @@ export const extensions: IFileCollection = {
     },
     {
       icon: 'gitlab',
-      extensions: ['.gitlab-ci.yml'],
+      extensions: ['.gitlab-ci.yml', '.gitlab-ci.yaml'],
       filename: true,
       format: FileFormat.svg,
     },


### PR DESCRIPTION
<!-- markdownlint-disable MD041-->

<!-- Please first read how to submit a pull request, if you haven't already done so.
https://github.com/vscode-icons/vscode-icons/wiki/PullRequest -->

_**Fixes #IssueNumber**_

**Changes proposed:**

- [X] Add
- [ ] Delete
- [ ] Fix
- [ ] Prepare

Although [the official GitLab documentation](https://docs.gitlab.com/ee/ci/yaml/) commonly references to this file as 'gitlab-ci-yml', in [the same file you can also see traces](https://docs.gitlab.com/ee/ci/yaml/#includelocal) that it also does allow .yaml to be used.

My close-sourced findings are that:
- the core, entrypoint file has to be named exactly `.gitlab-ci.yml`, so `.yaml` can't be used here
- the core, and any other files used can include other files even if the extension is `.yaml`

So we could assume that anything like`*gitlab-ci.yaml` that is not `.gitlab-ci.yml files could be used to organize partial files