### PR TITLE
feat(icon): add language-configuration icon

### DIFF
--- a/icons/file_type_language_configuration.svg
+++ b/icons/file_type_language_configuration.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32"><path fill="#fff" d="M30 4.33v23.34H2V4.33z"/><path fill="#167abf" d="M2 4.33h8.17v23.34H2zm28 0v23.34H12.5V4.33zM14.83 8.71h9.34V6.96h-9.34zm9.34 14.58h-9.34v1.75h9.34zm3.5-4.08h-9.34v1.75h9.34zm0-4.09h-9.34v1.75h9.34zm0-4.08h-9.34v1.75h9.34z"/></svg>

--- a/src/iconsManifest/supportedExtensions.ts
+++ b/src/iconsManifest/supportedExtensions.ts
@@ -2728,6 +2728,17 @@ export const extensions: IFileCollection = {
       format: FileFormat.svg,
     },
     {
+      icon: 'language_configuration',
+      extensions: ['language-configuration.json'],
+      filename: true,
+      format: FileFormat.svg,
+    },
+    {
+      icon: 'language_configuration',
+      extensions: ['language-configuration.json'],
+      format: FileFormat.svg,
+    },
+    {
       icon: 'layout',
       extensions: ['master', 'layout.html', 'layout.htm'],
       format: FileFormat.svg,


### PR DESCRIPTION
Language configuration files allow VSCode extensions to configure languages. See https://code.visualstudio.com/api/language-extensions/language-configuration-guide

These file names may prefix `language-configuration.json` with anything, but vscode-icons doesn’t support globs. Official extensions that come with VSCode use `.` as a separator, so I think it’s good to support that convention for the icon as well.

The language configuration format is part of Monaco editor, which is an integral part of VSCode. The icon was taken from the toolbar on https://microsoft.github.io/monaco-editor/.

<!-- markdownlint-disable MD041-->

<!-- Please first read how to submit a pull request, if you haven't already done so.
https://github.com/vscode-icons/vscode-icons/wiki/PullRequest -->

**Changes proposed:**

- [x] Add
- [ ] Delete
- [ ] Fix
- [ ] Prepare
