### PR TITLE
fix(typedoc): support additional config file names

### DIFF
--- a/src/iconsManifest/supportedExtensions.ts
+++ b/src/iconsManifest/supportedExtensions.ts
@@ -5151,7 +5151,7 @@ export const extensions: IFileCollection = {
       icon: 'typedoc',
       extensions: [],
       filenamesGlob: ['typedoc', 'typedoc.config'],
-      extensionsGlob: ['cjs', 'js', 'json', 'json5', 'mjs'],
+      extensionsGlob: ['cjs', 'js', 'json', 'jsonc', 'mjs'],
       filename: true,
       format: FileFormat.svg,
     },

--- a/src/iconsManifest/supportedExtensions.ts
+++ b/src/iconsManifest/supportedExtensions.ts
@@ -5150,8 +5150,8 @@ export const extensions: IFileCollection = {
     {
       icon: 'typedoc',
       extensions: [],
-      filenamesGlob: ['typedoc'],
-      extensionsGlob: ['js', 'json'],
+      filenamesGlob: ['typedoc', 'typedoc.config'],
+      extensionsGlob: ['cjs', 'js', 'json', 'json5', 'mjs'],
       filename: true,
       format: FileFormat.svg,
     },


### PR DESCRIPTION
<!-- markdownlint-disable MD041-->

<!-- Please first read how to submit a pull request, if you haven't already done so.
https://github.com/vscode-icons/vscode-icons/wiki/PullRequest -->

Adds support for all typedoc config file names: https://typedoc.org/options/configuration/#options

**Changes proposed:**

- [X] Add
- [ ] Delete
- [ ] Fix
- [ ] Prepare
