### PR TITLE
feat: add Quasar's new config extensions

### DIFF
--- a/src/iconsManifest/supportedExtensions.ts
+++ b/src/iconsManifest/supportedExtensions.ts
@@ -4132,7 +4132,9 @@ export const extensions: IFileCollection = {
     },
     {
       icon: 'quasar',
-      extensions: ['quasar.config.js', 'quasar.conf.js'],
+      extensions: ['quasar.conf.js'],
+      filenamesGlob: ['quasar.config'],
+      extensionsGlob: ['js', 'mjs', 'cjs', 'ts'],
       light: true,
       filename: true,
       format: FileFormat.svg,


### PR DESCRIPTION
**Changes proposed:**

- Add

Quasar Framework now supports `quasar.config.(js|mjs|cjs|ts)`:
- [`@quasar/app-vite v2` (release)](https://github.com/quasarframework/quasar/releases/tag/%40quasar%2Fapp-vite-v2.0.0-beta.1)
- [`@quasar/app-webpack v4` (release)](https://github.com/quasarframework/quasar/releases/tag/%40quasar%2Fapp-webpack-v4.0.0-beta.1)