### PR TITLE
feat(icon): support aptfile

### DIFF
--- a/src/iconsManifest/supportedExtensions.ts
+++ b/src/iconsManifest/supportedExtensions.ts
@@ -1386,6 +1386,13 @@ export const extensions: IFileCollection = {
       format: FileFormat.svg,
     },
     {
+      icon: 'debian',
+      extensions: ['aptfile'],
+      filename: true,
+      languages: [],
+      format: FileFormat.svg,
+    },
+    {
       icon: 'deno',
       extensions: [],
       filenamesGlob: ['deno'],


### PR DESCRIPTION
Use the debian icon for aptfile.

_**Fixes #3119**_

**Changes proposed:**

- [x] Add
- [ ] Delete
- [ ] Fix
- [ ] Prepare
