### PR TITLE
feat(icon): use app icon for application(s) folder

### DIFF
--- a/src/iconsManifest/supportedFolders.ts
+++ b/src/iconsManifest/supportedFolders.ts
@@ -14,7 +14,7 @@ export const extensions: IFolderCollection = {
     },
     {
       icon: 'app',
-      extensions: ['app', 'apps', '.app'],
+      extensions: ['app', 'apps', '.app', 'application', 'applications'],
       format: FileFormat.svg,
     },
     {


### PR DESCRIPTION
This uses the `app` folder icon for the `application` and `applications` folder. `app` is an abbreviation for `application`.

_**Fixes #3632**_

**Changes proposed:**

- [x] Add
- [ ] Delete
- [ ] Fix
- [ ] Prepare
