### PR TITLE
feat: add bun.lock to bun file types

### DIFF
--- a/src/iconsManifest/supportedExtensions.ts
+++ b/src/iconsManifest/supportedExtensions.ts
@@ -831,7 +831,7 @@ export const extensions: IFileCollection = {
     },
     {
       icon: 'bun',
-      extensions: ['bun', 'lockb'],
+      extensions: ['bun', 'lockb', 'bun.lock'],
       format: FileFormat.svg,
     },
     {


### PR DESCRIPTION
**Changes proposed:**

- [x] Add
- [ ] Delete
- [ ] Fix
- [ ] Prepare

This PR adds a capture for `bun.lock`, the upcoming default lock file format for Bun (available in canary today). See https://x.com/bunjavascript/status/1866879040424120625