### PR TITLE
feat(icon): support eleventy.config.mjs

### DIFF
--- a/src/iconsManifest/supportedExtensions.ts
+++ b/src/iconsManifest/supportedExtensions.ts
@@ -1676,14 +1676,24 @@ export const extensions: IFileCollection = {
     { icon: 'elasticbeanstalk', extensions: [], format: FileFormat.svg },
     {
       icon: 'eleventy',
-      extensions: ['.eleventy.js', 'eleventy.config.js', 'eleventy.config.cjs'],
+      extensions: [
+        '.eleventy.js',
+        'eleventy.config.js',
+        'eleventy.config.cjs',
+        'eleventy.config.mjs',
+      ],
       filename: true,
       light: true,
       format: FileFormat.svg,
     },
     {
       icon: 'eleventy2',
-      extensions: ['.eleventy.js', 'eleventy.config.js', 'eleventy.config.cjs'],
+      extensions: [
+        '.eleventy.js',
+        'eleventy.config.js',
+        'eleventy.config.cjs',
+        'eleventy.config.mjs',
+      ],
       filename: true,
       light: true,
       format: FileFormat.svg,

--- a/src/iconsManifest/supportedExtensions.ts
+++ b/src/iconsManifest/supportedExtensions.ts
@@ -3646,14 +3646,11 @@ export const extensions: IFileCollection = {
       format: FileFormat.svg,
     },
     { icon: 'ovpn', extensions: ['ovpn'], format: FileFormat.svg },
-    { 
+    {
       icon: 'oxlint',
-      extensions: [
-        '.oxlintignore',
-        '.oxlintrc.json',
-      ],
+      extensions: ['.oxlintignore', '.oxlintrc.json'],
       filename: true,
-      format: FileFormat.svg
+      format: FileFormat.svg,
     },
     { icon: 'package', extensions: ['pkg'], format: FileFormat.svg },
     {


### PR DESCRIPTION
Support for `eleventy.config.mjs` was added in Eleventy 3.0.0.

See https://www.11ty.dev/docs/config/#default-filenames

**Changes proposed:**

- [x] Add
