### PR TITLE
fix(docusaurus): correct extensionsGlob to not include prefix dot

### DIFF
--- a/src/iconsManifest/supportedExtensions.ts
+++ b/src/iconsManifest/supportedExtensions.ts
@@ -1557,7 +1557,7 @@ export const extensions: IFileCollection = {
       icon: 'docusaurus',
       extensions: [],
       filenamesGlob: ['docusaurus.config'],
-      extensionsGlob: ['.ts', '.mts', '.cts', '.js', '.mjs', '.cjs'],
+      extensionsGlob: ['ts', 'mts', 'cts', 'js', 'mjs', 'cjs'],
       filename: true,
       format: FileFormat.svg,
     },


### PR DESCRIPTION
with the prefix dot included, `vsicons-icon-theme.json` has `docusaurus.config..ts` as a generated value.

<!-- markdownlint-disable MD041-->

<!-- Please first read how to submit a pull request, if you haven't already done so.
https://github.com/vscode-icons/vscode-icons/wiki/PullRequest -->

_**Fixes #IssueNumber**_

**Changes proposed:**

- [ ] Add
- [ ] Delete
- [x] Fix
- [ ] Prepare
