### PR TITLE
feat(icon): add just icon

### DIFF
--- a/icons/file_type_just.svg
+++ b/icons/file_type_just.svg
@@ -1,0 +1,1 @@
+<svg viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg"><title>file_type_just</title><circle cx="16" cy="16" r="14"/><ellipse cx="16" cy="8.7" rx="3.8" ry="3.9" fill="#fff"/><ellipse cx="16" cy="23.3" rx="3.8" ry="3.9" fill="#fff"/></svg>

--- a/src/iconsManifest/languages.ts
+++ b/src/iconsManifest/languages.ts
@@ -235,6 +235,7 @@ export const languages = {
   jsonnet: { ids: 'jsonnet', defaultExtension: 'jsonnet' },
   json5: { ids: 'json5', defaultExtension: 'json5' },
   julia: { ids: ['julia', 'juliamarkdown'], defaultExtension: 'jl' },
+  just: { ids: 'just', defaultExtension: 'justfile' },
   iodine: { ids: 'iodine', defaultExtension: 'id' },
   k: { ids: 'k', defaultExtension: 'k' },
   kivy: { ids: 'kivy', defaultExtension: 'kv' },

--- a/src/iconsManifest/supportedExtensions.ts
+++ b/src/iconsManifest/supportedExtensions.ts
@@ -2762,6 +2762,12 @@ export const extensions: IFileCollection = {
     },
     { icon: 'jupyter', extensions: ['ipynb'], format: FileFormat.svg },
     {
+      icon: 'just',
+      extensions: [],
+      languages: [languages.just],
+      format: FileFormat.svg,
+    },
+    {
       icon: 'io',
       extensions: [],
       languages: [languages.io],


### PR DESCRIPTION
The `just` language ID is registered by
https://marketplace.visualstudio.com/items?itemName=skellock.just and https://marketplace.visualstudio.com/items?itemName=kokakiwi.vscode-just.

I manually recreated the icon to match the favicon of https://just.systems by overlaying it.

https://plugins.jetbrains.com/plugin/18658-just provides a verion of the icon where the holes are transparent. To me the white dots on a black circle look seem pretty iconic.

It also looks pretty good in dark mode in my opinion, despite the outer circle being black.

_**Fixes #2679**_

**Changes proposed:**

- [x] Add
