### PR TITLE
feat(icon): treat the oracle-sql language ID as plsql

### DIFF
--- a/src/iconsManifest/languages.ts
+++ b/src/iconsManifest/languages.ts
@@ -323,7 +323,10 @@ export const languages = {
     ],
     defaultExtension: 'dbgasm',
   },
-  plsql: { ids: ['plsql', 'oracle', 'oraclesql'], defaultExtension: 'ddl' },
+  plsql: {
+    ids: ['plsql', 'oracle', 'oraclesql', 'oracle-sql'],
+    defaultExtension: 'ddl',
+  },
   po: { ids: 'po', defaultExtension: 'po' },
   polymer: { ids: 'polymer', defaultExtension: 'polymer' },
   pony: { ids: 'pony', defaultExtension: 'pony' },


### PR DESCRIPTION
Their deprecated extension uses the `oraclesql` language ID. Their maintained extension uses `oracle-sql`.

_**Fixes #2745**_

**Changes proposed:**

- [x] Add
