### PR TITLE
feat(icon): add icon for .cursorrules

### DIFF
--- a/icons/file_type_cursorrules.svg
+++ b/icons/file_type_cursorrules.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32"><title>file_type_cursorrules</title><path fill="#444" d="M3.75,9V23H28.25V9L16,2"/><path fill="#939393" d="M16,16V2L3.75,9L28.25,23L16,30L3.75,23"/><path fill="#e3e3e3" d="M28.25,9H16V30"/><path fill="#fff" d="M3.75,9H28.25L16,16"/></svg>

--- a/src/iconsManifest/supportedExtensions.ts
+++ b/src/iconsManifest/supportedExtensions.ts
@@ -1336,6 +1336,12 @@ export const extensions: IFileCollection = {
       format: FileFormat.svg,
     },
     {
+      icon: 'cursorrules',
+      extensions: ['.cursorrules'],
+      filename: true,
+      format: FileFormat.svg,
+    },
+    {
       icon: 'cython',
       extensions: [],
       languages: [languages.cython],


### PR DESCRIPTION
The `.cursorrules` file is used by Cursor editor. See https://docs.cursor.com/context/rules-for-ai.

The icon is based on their favicon.

The icon is not available as SVG, so I recreated it manually.

**Changes proposed:**

- [x] Add