### PR TITLE
feat(icon): add cucumber language ID

### DIFF
--- a/src/iconsManifest/languages.ts
+++ b/src/iconsManifest/languages.ts
@@ -91,7 +91,7 @@ export const languages = {
     ],
     defaultExtension: 'csv',
   },
-  cucumber: { ids: 'feature', defaultExtension: 'feature' },
+  cucumber: { ids: ['cucumber', 'feature'], defaultExtension: 'feature' },
   cuda: { ids: ['cuda', 'cuda-cpp'], defaultExtension: 'cu' },
   cypher: { ids: 'cypher', defaultExtension: 'cypher' },
   cython: { ids: 'cython', defaultExtension: 'pyx' },


### PR DESCRIPTION
Previously the `feature` language ID was used for cucumber files. Now the official extension uses the `cucumber` language ID.

_**Fixes #3248**_

**Changes proposed:**

- [x] Add
