### PR TITLE
chore(vscode): trim svg newlines

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,6 +5,10 @@
   "[jsonc]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode"
   },
+  "[svg]": {
+    "files.insertFinalNewline": false,
+    "files.trimFinalNewlines": true
+  },
   "editor.codeActionsOnSave": {
     "source.fixAll.eslint": "explicit",
     "source.organizeImports": "explicit"


### PR DESCRIPTION
Configure VSCode to trim final newlines from SVG files.

Personally I would prefer to always add a trailing newline, but this setting matches the current status quo.
