### PR TITLE
feat(icon): support the taskfile icon

### DIFF
--- a/src/iconsManifest/supportedExtensions.ts
+++ b/src/iconsManifest/supportedExtensions.ts
@@ -5194,6 +5194,14 @@ export const extensions: IFileCollection = {
       format: FileFormat.svg,
     },
     {
+      icon: 'taskfile',
+      extensions: [],
+      format: FileFormat.svg,
+      filename: true,
+      filenamesGlob: ['taskfile', 'taskfile.dist'],
+      extensionsGlob: ['yml', 'yaml'],
+    },
+    {
       icon: 'tauri',
       extensions: ['tauri.conf.json', '.taurignore'],
       filename: true,

--- a/test/fixtures/supportedExtensions.ts
+++ b/test/fixtures/supportedExtensions.ts
@@ -1,5 +1,5 @@
-import { FileFormat, IFileCollection } from '../../src/models';
 import { languages } from '../../src/iconsManifest/languages';
+import { FileFormat, IFileCollection } from '../../src/models';
 
 export const extensions: IFileCollection = {
   default: {
@@ -518,14 +518,6 @@ export const extensions: IFileCollection = {
       languages: [languages.json, languages.textmatejson, languages.jsonc],
       format: FileFormat.svg,
       disabled: true,
-    },
-    {
-      icon: 'taskfile',
-      extensions: [],
-      format: FileFormat.svg,
-      filename: true,
-      filenamesGlob: ['Taskfile', 'Taskfile.dist'],
-      extensionsGlob: ['yml', 'yaml'],
     },
     {
       icon: 'typescript',


### PR DESCRIPTION
The icon was added in #3244, but the metadata was added in a test fixture instead of the builtin extensions file. This moves it into the proper file.

_**Fixes #3289**_

**Changes proposed:**

- [x] Fix