### PR TITLE
Add support for `svelte` extensions with Storybook

### DIFF
--- a/src/iconsManifest/supportedExtensions.ts
+++ b/src/iconsManifest/supportedExtensions.ts
@@ -5072,7 +5072,7 @@ export const extensions: IFileCollection = {
       icon: 'storybook',
       extensions: [],
       filenamesGlob: ['story', 'stories'],
-      extensionsGlob: ['js', 'jsx', 'ts', 'tsx', 'mdx'],
+      extensionsGlob: ['js', 'jsx', 'ts', 'tsx', 'mdx', 'svelte'],
       format: FileFormat.svg,
     },
     {


### PR DESCRIPTION
<!-- markdownlint-disable MD041-->

<!-- Please first read how to submit a pull request, if you haven't already done so.
https://github.com/vscode-icons/vscode-icons/wiki/PullRequest -->

<!--  _**Fixes #IssueNumber**_ -->

The [Storybook Svelte CSF addon](https://github.com/storybookjs/addon-svelte-csf) allows us to write stories using `.stories.svelte` files.

This PR aims to display the Storybook icon for files with such extensions.

| Before | After |
|--------|--------|
| <img width="195" alt="Screenshot 2025-02-08 at 10 50 37" src="https://github.com/user-attachments/assets/7578abd8-a6a9-4507-90bd-9e5be3e43f62" /> | <img width="191" alt="Screenshot 2025-02-08 at 10 50 46" src="https://github.com/user-attachments/assets/2227f067-234d-48fd-831f-947d2016b2e4" /> | 

**Changes proposed:**

- [x] Add
- [ ] Delete
- [ ] Fix
- [ ] Prepare
