### PR TITLE
feat(icon): support for .git files inside git submodules

### DIFF
--- a/src/iconsManifest/supportedExtensions.ts
+++ b/src/iconsManifest/supportedExtensions.ts
@@ -2102,6 +2102,7 @@ export const extensions: IFileCollection = {
     {
       icon: 'git',
       extensions: [
+        '.git',
         '.gitattributes',
         '.gitconfig',
         '.gitignore',


### PR DESCRIPTION
_**Fixes #3733**_

**Changes proposed:**

- [X] Add
- [X] Fix

Add `.git` file extension to the list which should use the git icon as file icon.