### PR TITLE
Add more extensions for `xo.config` file

### DIFF
--- a/src/iconsManifest/supportedExtensions.ts
+++ b/src/iconsManifest/supportedExtensions.ts
@@ -6086,7 +6086,7 @@ export const extensions: IFileCollection = {
       icon: 'xo',
       extensions: [],
       filenamesGlob: ['xo.config'],
-      extensionsGlob: ['js', 'cjs'],
+      extensionsGlob: ['js', 'cjs', 'mjs', 'ts', 'cts', 'mts'],
       filename: true,
       format: FileFormat.svg,
     },


### PR DESCRIPTION
**Changes proposed:**

- [x] Add
- [ ] Delete
- [ ] Fix
- [ ] Prepare

Add all supported extensions for *xo.config* files. See [v0.61.0-0 release notes](https://github.com/xojs/xo/releases/tag/v0.61.0-0):

> - Configuration now only through `package.json` and `xo.config.{js,cjs,mjs,ts,cts,mts}` files