### PR TITLE
feat(icon): support instructions and prompt languages

### DIFF
--- a/src/iconsManifest/languages.ts
+++ b/src/iconsManifest/languages.ts
@@ -81,6 +81,10 @@ export const languages = {
   coldfusion: { ids: ['cfml', 'lang-cfml'], defaultExtension: 'cfml' },
   confluence: { ids: ['confluence'], defaultExtension: 'confluence' },
   cookbook: { ids: 'cookbook', defaultExtension: 'ckbk' },
+  copilot: {
+    ids: ['instructions', 'prompt'],
+    defaultExtension: 'instructions.md',
+  },
   cpp: { ids: 'cpp', defaultExtension: 'cpp' },
   crystal: { ids: 'crystal', defaultExtension: 'cr' },
   csharp: { ids: 'csharp', defaultExtension: 'cs' },

--- a/src/iconsManifest/supportedExtensions.ts
+++ b/src/iconsManifest/supportedExtensions.ts
@@ -1238,6 +1238,7 @@ export const extensions: IFileCollection = {
       icon: 'copilot',
       extensions: ['copilot-instructions.md', 'github-copilot.xml'],
       filename: true,
+      languages: [languages.copilot],
       light: true,
       format: FileFormat.svg,
     },


### PR DESCRIPTION
VSCode 1.100 added support for the new `instructions` and `prompt` languages. THese are used for Copilot integration.

**Changes proposed:**

- [x] Add