### PR TITLE
feat(icon): add shadcn icon

### DIFF
--- a/icons/file_type_light_shadcn.svg
+++ b/icons/file_type_light_shadcn.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32"><path d="m27.76 16.56-11.2 11.2m8.96-23.52-21.28 21.28" stroke="#000" stroke-linecap="round" stroke-width="4.48"/></svg>

--- a/icons/file_type_shadcn.svg
+++ b/icons/file_type_shadcn.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32"><path d="m27.76 16.56-11.2 11.2m8.96-23.52-21.28 21.28" stroke="#dedede" stroke-linecap="round" stroke-width="4.48"/></svg>

--- a/src/iconsManifest/supportedExtensions.ts
+++ b/src/iconsManifest/supportedExtensions.ts
@@ -4941,6 +4941,13 @@ export const extensions: IFileCollection = {
       format: FileFormat.svg,
     },
     {
+      icon: 'shadcn',
+      extensions: ['components.json'],
+      filename: true,
+      light: true,
+      format: FileFormat.svg,
+    },
+    {
       icon: 'shell',
       extensions: ['fish'],
       languages: [languages.shellscript],


### PR DESCRIPTION
Both the icon and filename are based on https://ui.shadcn.com/docs/components-json.

_**Fixes #3664**_

**Changes proposed:**

- [x] Add