### PR TITLE
feat(icon): update `turbo` icon to handle `turbo.jsonc`

### DIFF
--- a/src/iconsManifest/supportedExtensions.ts
+++ b/src/iconsManifest/supportedExtensions.ts
@@ -6270,7 +6270,7 @@ export const extensions: IFileCollection = {
     },
     {
       icon: 'turbo',
-      extensions: ['turbo.json'],
+      extensions: ['turbo.json', 'turbo.jsonc'],
       light: true,
       filename: true,
       format: FileFormat.svg,


### PR DESCRIPTION
As of the _recent_ https://github.com/vercel/turborepo/pull/10083, Turborepo now supports a `turbo.jsonc` config file. This PR adjusts the existing `turbo.json` setting to cover the `jsonc` extension too.

**Changes proposed:**

- [x] Add