### PR TITLE
feat(svelte): add svelte.config.ts as svelteconfig extension

### DIFF
--- a/src/iconsManifest/supportedExtensions.ts
+++ b/src/iconsManifest/supportedExtensions.ts
@@ -5233,7 +5233,7 @@ export const extensions: IFileCollection = {
     },
     {
       icon: 'svelteconfig',
-      extensions: ['svelte.config.js'],
+      extensions: ['svelte.config.js', 'svelte.config.ts'],
       filename: true,
       format: FileFormat.svg,
     },


### PR DESCRIPTION
<!-- markdownlint-disable MD041-->

<!-- Please first read how to submit a pull request, if you haven't already done so.
https://github.com/vscode-icons/vscode-icons/wiki/PullRequest -->

_**Fixes #IssueNumber**_

**Changes proposed:**

- [x] Add
- [ ] Delete
- [ ] Fix
- [ ] Prepare


SvelteKit now supports `svelte.config.ts` as a valid configuration file alongside `svelte.config.js`.

This PR updates the icon mapping to recognize and apply the existing `svelteconfig` icon for the `.ts` variant.