### PR TITLE
Add support for 'store' and 'stores' folder types

### DIFF
--- a/src/iconsManifest/supportedFolders.ts
+++ b/src/iconsManifest/supportedFolders.ts
@@ -194,6 +194,8 @@ export const extensions: IFolderCollection = {
         'repo',
         'repository',
         'repositories',
+        'store',
+        'stores'
       ],
       format: FileFormat.svg,
     },


### PR DESCRIPTION
In modern web frameworks, store and stores folders are conventional for state management (Pinia, Redux),

This PR maps the database icon to these folders, providing immediate visual recognition.

<img width="229" height="158" alt="image" src="https://github.com/user-attachments/assets/43a52b30-2be4-4c7e-b428-55d3f51e49bc" />

