### PR TITLE
chore(icon): use jekyll icon for .nojekyll

### DIFF
--- a/src/iconsManifest/supportedExtensions.ts
+++ b/src/iconsManifest/supportedExtensions.ts
@@ -2738,7 +2738,8 @@ export const extensions: IFileCollection = {
     },
     {
       icon: 'jekyll',
-      extensions: [],
+      extensions: ['.nojekyll'],
+      filename: true,
       languages: [languages.jekyll],
       format: FileFormat.svg,
     },


### PR DESCRIPTION
The `.nojekyll` file is used to tell GitHub pages to bypasst Jekyll.

**Changes proposed:**

- [x] Add