### PR TITLE
feat(icon): extend to pytest toml config files

### DIFF
--- a/src/iconsManifest/supportedExtensions.ts
+++ b/src/iconsManifest/supportedExtensions.ts
@@ -4569,7 +4569,7 @@ export const extensions: IFileCollection = {
     },
     {
       icon: 'pytest',
-      extensions: ['pytest.ini', '.pytest.ini'],
+      extensions: ['pytest.ini', '.pytest.ini', 'pytest.toml', '.pytest.toml'],
       filename: true,
       format: FileFormat.svg,
     },


### PR DESCRIPTION
pytest [v9.0.0](https://github.com/pytest-dev/pytest/releases/tag/9.0.0) introduces support for standalone `pytest.toml` and `.pytest.toml` configuration files - see [configuration documentation](https://docs.pytest.org/en/stable/reference/customize.html#pytest-toml).

**Changes proposed:**

- [x] Add