### PR TITLE
fix: add support for TS files for capacitor config icon

### DIFF
--- a/src/iconsManifest/supportedExtensions.ts
+++ b/src/iconsManifest/supportedExtensions.ts
@@ -965,7 +965,7 @@ export const extensions: IFileCollection = {
     {
       icon: 'capacitor',
       extensions: [],
-      extensionsGlob: ['json'],
+      extensionsGlob: ['json', 'ts'],
       filename: true,
       filenamesGlob: ['capacitor.config'],
       format: FileFormat.svg,


### PR DESCRIPTION
<!-- markdownlint-disable MD041-->

<!-- Please first read how to submit a pull request, if you haven't already done so.
https://github.com/vscode-icons/vscode-icons/wiki/PullRequest -->

**Changes proposed:**

- [ ] Add
- [ ] Delete
- [x] Fix
- [ ] Prepare

Capacitor icon would only appear for `capacitor.config.json` file. This adds support for the [supported](https://capacitorjs.com/docs/config) `capacitor.config.ts` file.