### PR TITLE
feat(icon): add support for the oxlint jsonc configuration file

### DIFF
--- a/src/iconsManifest/supportedExtensions.ts
+++ b/src/iconsManifest/supportedExtensions.ts
@@ -3966,7 +3966,13 @@ export const extensions: IFileCollection = {
     { icon: 'ovpn', extensions: ['ovpn'], format: FileFormat.svg },
     {
       icon: 'oxc',
-      extensions: ['.oxlintignore', '.oxlintrc.json', '.oxfmtrc.json'],
+      extensions: [
+        '.oxlintignore',
+        '.oxlintrc.json',
+        '.oxlintrc.jsonc',
+        '.oxfmtrc.json',
+        '.oxfmtrc.jsonc',
+      ],
       filename: true,
       format: FileFormat.svg,
     },


### PR DESCRIPTION

**Changes proposed:**

- [x] Add
- [ ] Delete
- [ ] Fix
- [ ] Prepare

According to the official oxc documentation, oxc supports `.json` and `.jsonc` configuration files.

[oxlint configuration file](https://oxc.rs/docs/guide/usage/linter/config.html#configuration-file-format)

[oxfmt configuration file](https://oxc.rs/docs/guide/usage/formatter.html#configuration-file)