### PR TITLE
feat(icon): update lefthook icon file extensions

### DIFF
--- a/src/iconsManifest/supportedExtensions.ts
+++ b/src/iconsManifest/supportedExtensions.ts
@@ -3063,16 +3063,14 @@ export const extensions: IFileCollection = {
     },
     {
       icon: 'lefthook',
-      extensions: [
-        '.lefthook.json',
-        '.lefthook.toml',
-        '.lefthook.yaml',
-        '.lefthook.yml',
-        'lefthook.json',
-        'lefthook.toml',
-        'lefthook.yaml',
-        'lefthook.yml',
+      extensions: [],
+      filenamesGlob: [
+        'lefthook',
+        'lefthook-local',
+        '.lefthook',
+        '.lefthook-local',
       ],
+      extensionsGlob: ['json', 'toml', 'yaml', 'yml'],
       filename: true,
       format: FileFormat.svg,
     },


### PR DESCRIPTION
<!-- markdownlint-disable MD041-->

<!-- Please first read how to submit a pull request, if you haven't already done so.
https://github.com/vscode-icons/vscode-icons/wiki/PullRequest -->

**Changes proposed:**

- [ ] Add
- [ ] Delete
- [x] Fix
- [ ] Prepare

Fixes: #3832

Lefthook supports multiple config file formats and names, as per their [Documentation](https://lefthook.dev/configuration/). This PR addresses adding additional file names and extensions.
