### PR TITLE
fix: add missing lefthook files

### DIFF
--- a/src/iconsManifest/supportedExtensions.ts
+++ b/src/iconsManifest/supportedExtensions.ts
@@ -3063,7 +3063,16 @@ export const extensions: IFileCollection = {
     },
     {
       icon: 'lefthook',
-      extensions: ['lefthook.yml', 'lefthook.yaml'],
+      extensions: [
+        '.lefthook.json',
+        '.lefthook.toml',
+        '.lefthook.yaml',
+        '.lefthook.yml',
+        'lefthook.json',
+        'lefthook.toml',
+        'lefthook.yaml',
+        'lefthook.yml',
+      ],
       filename: true,
       format: FileFormat.svg,
     },


### PR DESCRIPTION
**Changes proposed:**

- [ ] Add
- [ ] Delete
- [x] Fix
- [ ] Prepare

There are more valid names for the lefthook configuration files than are present in the config. See the entire list here: https://lefthook.dev/configuration/index.html