### PR TITLE
feat(icon): allure

### DIFF
--- a/icons/file_type_allure.svg
+++ b/icons/file_type_allure.svg
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg fill="none" version="1.1" viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg">
+ <g transform="matrix(.8 0 0 .8 3.198 3.2)" clip-path="url(#a)">
+  <g clip-rule="evenodd" fill-rule="evenodd">
+   <path d="m22.23 4.66a3.6 3.6 0 0 1 5.1 0.04 16.08 16.08 0 0 1 4.64 11.3 3.6 3.6 0 1 1-7.2 0c0-2.4-0.98-4.61-2.58-6.24a3.6 3.6 0 0 1 0.03-5.1z" fill="url(#b)"/>
+   <path d="m12.4 3.6a3.6 3.6 0 0 1 3.6-3.6c4.4 0 8.4 1.8 11.29 4.66a3.6028 3.6028 0 0 1-5.06 5.13 8.87 8.87 0 0 0-6.23-2.59 3.6 3.6 0 0 1-3.6-3.6z" fill="url(#c)"/>
+   <path d="m0 16a16 16 0 0 1 16-16 3.6 3.6 0 0 1 0 7.2 8.8 8.8 0 0 0-6.21 15.04 3.6028 3.6028 0 0 1-5.13 5.06 16.08 16.08 0 0 1-4.66-11.3z" fill="url(#d)"/>
+   <path d="m4.66 22.24a3.6 3.6 0 0 1 5.1-0.03 8.87 8.87 0 0 0 6.23 2.59 3.6 3.6 0 0 1 0 7.2c-4.4 0-8.4-1.8-11.3-4.66a3.6 3.6 0 0 1-0.03-5.1z" fill="url(#e)"/>
+   <path d="m28.38 12.4a3.6 3.6 0 0 1 3.6 3.6 16 16 0 0 1-15.98 16 3.6 3.6 0 0 1 0-7.2 8.8 8.8 0 0 0 8.8-8.8 3.6 3.6 0 0 1 3.6-3.6z" fill="url(#f)"/>
+   <path d="m28.38 12.4a3.6 3.6 0 0 1 3.6 3.6v12.4a3.6 3.6 0 1 1-7.2 0v-12.4a3.6 3.6 0 0 1 3.6-3.6z" fill="url(#g)"/>
+  </g>
+  <g clip-path="url(#h)">
+   <path d="m22.23 4.66a3.6 3.6 0 0 1 5.1 0.04 16.08 16.08 0 0 1 4.64 11.3 3.6 3.6 0 1 1-7.2 0c0-2.4-0.98-4.61-2.58-6.24a3.6 3.6 0 0 1 0.03-5.1z" clip-rule="evenodd" fill="url(#b)" fill-rule="evenodd"/>
+  </g>
+ </g>
+ <defs>
+  <linearGradient id="b" x1="26.4" x2="28.8" y1="9.6" y2="15.01" gradientUnits="userSpaceOnUse">
+   <stop stop-color="#7E22CE" offset="0"/>
+   <stop stop-color="#8B5CF6" offset="1"/>
+  </linearGradient>
+  <linearGradient id="c" x1="26.8" x2="17.8" y1="9.4" y2="3.61" gradientUnits="userSpaceOnUse">
+   <stop stop-color="#EF4444" offset="0"/>
+   <stop stop-color="#DC2626" offset="1"/>
+  </linearGradient>
+  <linearGradient id="d" x1="3.6" x2="5.4" y1="14.01" y2="24.81" gradientUnits="userSpaceOnUse">
+   <stop stop-color="#22C55E" offset="0"/>
+   <stop stop-color="#15803D" offset="1"/>
+  </linearGradient>
+  <linearGradient id="e" x1="4.8" x2="14.4" y1="22.21" y2="29.21" gradientUnits="userSpaceOnUse">
+   <stop stop-color="#94A3B8" offset="0"/>
+   <stop stop-color="#64748B" offset=".96"/>
+   <stop stop-color="#64748B" offset="1"/>
+  </linearGradient>
+  <linearGradient id="f" x1="28.4" x2="22.19" y1="22.18" y2="28.4" gradientUnits="userSpaceOnUse">
+   <stop stop-color="#D97706" offset="0"/>
+   <stop stop-color="#FBBF24" offset="1"/>
+  </linearGradient>
+  <linearGradient id="g" x1="29.2" x2="30.63" y1="54.43" y2="54.28" gradientUnits="userSpaceOnUse">
+   <stop stop-color="#FBBF24" offset="0"/>
+   <stop stop-color="#FBBF24" offset="1"/>
+  </linearGradient>
+  <clipPath id="a">
+   <path d="M0 0h32v32H0z" fill="#fff"/>
+  </clipPath>
+  <clipPath id="h">
+   <path d="M24.8 12H32v8h-7.2z" fill="#fff"/>
+  </clipPath>
+ </defs>
+</svg>

--- a/src/iconsManifest/supportedExtensions.ts
+++ b/src/iconsManifest/supportedExtensions.ts
@@ -78,6 +78,11 @@ export const extensions: IFileCollection = {
       languages: [languages.advpl],
       format: FileFormat.svg,
     },
+    {
+      icon: 'affinity',
+      extensions: ['af', 'aftemplate'],
+      format: FileFormat.svg,
+    },
     { icon: 'ai', extensions: ['ai'], format: FileFormat.svg },
     { icon: 'ai2', extensions: ['ai'], format: FileFormat.svg, disabled: true },
     {
@@ -98,8 +103,16 @@ export const extensions: IFileCollection = {
       format: FileFormat.svg,
     },
     {
-      icon: 'affinity',
-      extensions: ['af', 'aftemplate'],
+      icon: 'allure',
+      extensions: [
+        'allurerc.js',
+        'allurerc.mjs',
+        'allurerc.cjs',
+        'allurerc.json',
+        'allurerc.yaml',
+        'allurerc.yml',
+      ],
+      filename: true,
       format: FileFormat.svg,
     },
     {


### PR DESCRIPTION
**Changes proposed:**

- [x] Add

[Allure configuration files](https://allurereport.org/docs/v3/configure/#file-name-and-location) support - opening [`report-logo.svg`](https://github.com/allure-framework/allure3/blob/204c4c7ab95f901b73b237e489b5d7b8e6c15539/packages/web-components/src/assets/svg/report-logo.svg) within [Inkscape](https://inkscape.org), applying an 80% scale transform and saving as an optimised SVG.

<img width="441" height="290" alt="allure-vscode-icons" src="https://github.com/user-attachments/assets/43cf0057-3a3e-4b93-a21f-bbea6ea6bb11" />