### PR TITLE
Specify ignore-scripts=false in .npmrc

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,3 @@
 engine-strict=true
 fund=false
+ignore-scripts=false


### PR DESCRIPTION
This project depends on npm lifecycle scripts. This enables them, even if they are disabled on a developer machine.