### PR TITLE
Add azure pipelines folder names mentioned in official documentation

### DIFF
--- a/src/iconsManifest/supportedFolders.ts
+++ b/src/iconsManifest/supportedFolders.ts
@@ -57,7 +57,12 @@ export const extensions: IFolderCollection = {
     { icon: 'azure', extensions: ['azure', '.azure'], format: FileFormat.svg },
     {
       icon: 'azurepipelines',
-      extensions: ['azure-pipelines', '.azure-pipelines', '.azuredevops', '.vsts'],
+      extensions: [
+        'azure-pipelines',
+        '.azure-pipelines',
+        '.azuredevops',
+        '.vsts',
+      ],
       format: FileFormat.svg,
     },
     { icon: 'binary', extensions: ['bin', '.bin'], format: FileFormat.svg },


### PR DESCRIPTION
There are no related issues.

**Changes proposed:**

- [X] Fix

The [official azure pipelines documentation](https://learn.microsoft.com/en-us/azure/devops/repos/git/pull-request-templates?view=azure-devops#default-pull-request-templates) mentions two folder names I would like to add to the registered folder names (aka extensions).
