### PR TITLE
feat(icon): use markdown icon for chatagent language

### DIFF
--- a/src/iconsManifest/languages.ts
+++ b/src/iconsManifest/languages.ts
@@ -330,7 +330,7 @@ export const languages = {
   m4: { ids: 'm4', knownExtensions: ['m4'] },
   makefile: { ids: ['makefile', 'makefile2'], knownExtensions: ['mk'] },
   markdown: {
-    ids: 'markdown',
+    ids: ['chatagent', 'markdown'],
     knownExtensions: ['md', 'markdown', 'mdown', 'mkd'],
   },
   marko: { ids: 'marko', knownExtensions: ['marko'] },


### PR DESCRIPTION
The `chatagent` language is builtin to VSCode. It’s a Markdown file with a special purpose. It may be better to use a dedicated icon for this, but I’m not sure which. Using the Markdown icon is better than nothing.

**Changes proposed:**

- [x] Add