### PR TITLE
feat(icon): support .bun-version

### DIFF
--- a/src/iconsManifest/supportedExtensions.ts
+++ b/src/iconsManifest/supportedExtensions.ts
@@ -918,7 +918,13 @@ export const extensions: IFileCollection = {
     },
     {
       icon: 'bun',
-      extensions: ['.bunfig.toml', 'bunfig.toml', 'bun.lockb', 'bun.lock'],
+      extensions: [
+        '.bun-version',
+        '.bunfig.toml',
+        'bunfig.toml',
+        'bun.lockb',
+        'bun.lock',
+      ],
       languages: [languages.bunlockb],
       filename: true,
       format: FileFormat.svg,


### PR DESCRIPTION
This uses the `bun` icon for files named `.bun-version`.

This file name is suggested by their official GitHub action: https://github.com/oven-sh/setup-bun

_**Fixes #3990**_

**Changes proposed:**

- [x] Add
