### PR TITLE
fix: sync welcome-shown state via Settings Sync

### DIFF
--- a/src/app/extensionManager.ts
+++ b/src/app/extensionManager.ts
@@ -56,6 +56,12 @@ export class ExtensionManager implements models.IExtensionManager {
       ConfigManager.rootDir = resolve(dirname(__filename), '../../');
     }
 
+    // Mark extension state for Settings Sync so welcome-shown
+    // status is preserved across synced machines
+    this.vscodeManager.context.globalState.setKeysForSync([
+      constants.vsicons.name,
+    ]);
+
     // function calls has to be done in this order strictly
     await this.settingsManager.moveStateFromLegacyPlace();
 

--- a/src/models/vscode/vscodeMemento.ts
+++ b/src/models/vscode/vscodeMemento.ts
@@ -4,4 +4,5 @@ export interface IVSCodeMemento {
   get<T>(key: string): T | undefined;
   get<T>(key: string, defaultValue: T): T;
   update(key: string, value: any): Thenable<void>;
+  setKeysForSync(keys: readonly string[]): void;
 }

--- a/test/app/extensionManager.test.ts
+++ b/test/app/extensionManager.test.ts
@@ -40,6 +40,7 @@ describe('ExtensionManager: tests', function () {
 
       sandbox.stub(vscodeManagerStub, 'context').get(() => ({
         subscriptions: [],
+        globalState: { setKeysForSync: sandbox.stub() },
       }));
       onDidChangeConfigurationStub = sandbox.stub();
       sandbox.stub(vscodeManagerStub, 'workspace').get(() => ({


### PR DESCRIPTION
Calls `globalState.setKeysForSync()` during extension activation so the extension state (including `welcomeShown`) is included when users sync VS Code settings across machines. Without this, users who install via Settings Sync see the welcome message again on every synced machine.

Added `setKeysForSync` to `IVSCodeMemento` interface to match the VS Code 1.51+ Memento API.

Fixes #2655

This contribution was developed with AI assistance (Claude Code).