### PR TITLE
feat(icon): support .biome.json and .biome.jsonc

### DIFF
--- a/src/iconsManifest/supportedExtensions.ts
+++ b/src/iconsManifest/supportedExtensions.ts
@@ -4699,7 +4699,7 @@ export const extensions: IFileCollection = {
     },
     {
       icon: 'biome',
-      extensions: ['biome.json', 'biome.jsonc'],
+      extensions: ['biome.json', 'biome.jsonc', '.biome.json', '.biome.jsonc'],
       filename: true,
       languages: [languages.biomesyntaxtree],
       format: FileFormat.svg,


### PR DESCRIPTION
<!-- markdownlint-disable MD041-->

Support `.biome.json` and `.biome.jsonc` files for the Biome icon, since they're also discoverable by the tool. [Docs here](https://biomejs.dev/guides/configure-biome/#configuration-file-resolution).

<!-- Please first read how to submit a pull request, if you haven't already done so.
https://github.com/vscode-icons/vscode-icons/wiki/PullRequest -->

**Changes proposed:**

- [x] Add
- [ ] Delete
- [ ] Fix
- [ ] Prepare