### PR TITLE
feat(icon): add support for jsr.jsonc

### DIFF
--- a/src/iconsManifest/supportedExtensions.ts
+++ b/src/iconsManifest/supportedExtensions.ts
@@ -3014,7 +3014,7 @@ export const extensions: IFileCollection = {
     { icon: 'jsp', extensions: ['jsp'], format: FileFormat.svg },
     {
       icon: 'jsr',
-      extensions: ['jsr.json'],
+      extensions: ['jsr.json', 'jsr.jsonc'],
       filename: true,
       format: FileFormat.svg,
     },


### PR DESCRIPTION
We only had support for `jsr.json`. However, this file may also use the `jsonc` extension.

See https://jsr.io/docs/package-configuration#jsrjson-file

**Changes proposed:**

- [x] Add