### PR TITLE
feat(icon): add .opentofu-version filename support

### DIFF
--- a/src/iconsManifest/supportedExtensions.ts
+++ b/src/iconsManifest/supportedExtensions.ts
@@ -4089,6 +4089,12 @@ export const extensions: IFileCollection = {
       format: FileFormat.svg,
     },
     {
+      icon: 'opentofu',
+      extensions: ['.opentofu-version'],
+      filename: true,
+      format: FileFormat.svg,
+    },
+    {
       icon: 'org',
       extensions: ['org'],
       languages: [languages.org],


### PR DESCRIPTION
_**Fixes #4029**_

**Changes proposed:**

- [x] Add
- [ ] Delete
- [ ] Fix
- [ ] Prepare

## Summary

Associate the existing `opentofu` icon with the `.opentofu-version` filename used by the OpenTofu version managers `tofuenv` and `tenv`.

Reuses the existing `icons/file_type_opentofu.svg` (no new SVG).

## Why a separate entry

Added as a separate entry rather than merged into the existing `opentofu` extensions entry, mirroring the `ruby` / `.ruby-version` precedent (line 5087-5098). This:

1. Keeps the OpenTofu CLI file extensions (`tofu`, `tofu.json`, etc.) — which are owned by the OpenTofu project — distinct from `.opentofu-version`, which is a tofuenv/tenv community convention.
2. Allows a future migration to a dedicated tofuenv-specific icon by changing only the `icon` field of the new entry, leaving the existing OpenTofu mapping untouched.

## Verification

- `npm run lint` ✅
- `npm test` (707 passing) ✅
- `npm run build:dev` ✅
- Generated `vsicons-icon-theme.json` contains `".opentofu-version": "_f_opentofu"` in `fileNames` (and same for `vsicons-icon-theme-zed.json`).
