### PR TITLE
feat: add textproto to protobuf language ID

### DIFF
--- a/src/iconsManifest/languages.ts
+++ b/src/iconsManifest/languages.ts
@@ -454,7 +454,7 @@ export const languages = {
     knownExtensions: ['properties'],
   },
   protobuf: {
-    ids: ['proto3', 'proto', 'prototext'],
+    ids: ['proto3', 'proto', 'prototext', 'textproto'],
     knownExtensions: ['proto'],
   },
   pug: { ids: 'jade', knownExtensions: ['pug'] },


### PR DESCRIPTION
_**Fixes #NA**_

**Changes proposed:**

- [x] Add

Add `textproto` to `protobuf` language ID used by this VS Code extension: https://marketplace.visualstudio.com/items?itemName=DrBlury.protobuf-vsc.

This change aligns with the currently maintained Protobuf extension, as the previously most-downloaded extension: https://marketplace.visualstudio.com/items?itemName=zxh404.vscode-proto3 has been deprecated and now redirects users to the extension above.

<img width="1043" height="225" alt="image" src="https://github.com/user-attachments/assets/f4be5cc5-811b-410c-b29f-b5d3ce4ffd86" />
