### PR TITLE
feat: add eas.json to expo

### DIFF
--- a/src/iconsManifest/supportedExtensions.ts
+++ b/src/iconsManifest/supportedExtensions.ts
@@ -2071,6 +2071,7 @@ export const extensions: IFileCollection = {
         'app.config.js',
         'app.config.json',
         'app.config.json5',
+        'eas.json',
       ],
       light: true,
       filename: true,


### PR DESCRIPTION
_**Fixes #N/A**_

**Changes proposed:**

- [x] Add

The `eas.json` file is used to configure [EAS CLI and related Expo services](https://docs.expo.dev/build/eas-json/).