### PR TITLE
fix(nest): detect NestJS projects via nest config files

### DIFF
--- a/src/pad/projectAutoDetectionManager.ts
+++ b/src/pad/projectAutoDetectionManager.ts
@@ -5,6 +5,7 @@ import { ManifestReader } from '../iconsManifest';
 import * as models from '../models';
 import { IPackageManifest } from '../models/packageManifest';
 import { Utils } from '../utils';
+import { basename } from 'node:path';
 
 export class ProjectAutoDetectionManager
   implements models.IProjectAutoDetectionManager
@@ -29,17 +30,29 @@ export class ProjectAutoDetectionManager
     }
 
     try {
-      const results = (await (this.configManager.vsicons.projectDetection
-        .disableDetect
-        ? Promise.resolve(null)
-        : this.vscodeManager.workspace.findFiles(
-            '**/package.json',
-            '**/node_modules/**',
-          ))) as models.IVSCodeUri[];
+      const results = this.configManager.vsicons.projectDetection.disableDetect
+        ? null
+        : await this.findProjectFiles();
       return this.detect(results, projects);
     } catch (error: unknown) {
       ErrorHandler.logError(error);
     }
+  }
+
+  private async findProjectFiles(): Promise<models.IVSCodeUri[]> {
+    const patterns = [
+      '**/package.json',
+      '**/nest-cli.json',
+      '**/.nest-cli.json',
+      '**/nestconfig.json',
+      '**/.nestconfig.json',
+    ];
+    const results = await Promise.all(
+      patterns.map(pattern =>
+        this.vscodeManager.workspace.findFiles(pattern, '**/node_modules/**'),
+      ),
+    );
+    return results.flat();
   }
 
   private async detect(
@@ -208,6 +221,11 @@ export class ProjectAutoDetectionManager
   ): Promise<models.IProjectInfo> {
     let projectInfo: models.IProjectInfo = null;
     for (const result of results) {
+      const fileName = basename(result.fsPath);
+      if (project === models.Projects.nestjs && this.isNestProjectFile(fileName)) {
+        projectInfo = { name: project, version: '' };
+        break;
+      }
       const content: string = await readFileAsync(result.fsPath, 'utf8');
       const projectJson: IPackageManifest =
         Utils.parseJSONSafe<IPackageManifest>(content);
@@ -217,6 +235,15 @@ export class ProjectAutoDetectionManager
       }
     }
     return projectInfo;
+  }
+
+  private isNestProjectFile(fileName: string): boolean {
+    return [
+      'nest-cli.json',
+      '.nest-cli.json',
+      'nestconfig.json',
+      '.nestconfig.json',
+    ].includes(fileName);
   }
 
   private getInfo(

--- a/test/pad/nestjsDetection.test.ts
+++ b/test/pad/nestjsDetection.test.ts
@@ -65,7 +65,9 @@ describe('ProjectAutoDetectionManager: NestJS project tests', function () {
 
       beforeEach(function () {
         vsicons.projectDetection.disableDetect = false;
-        findFilesStub.resolves([{ fsPath: packageJsonPath }]);
+        findFilesStub.callsFake((pattern: string) =>
+          pattern.includes('package.json') ? [{ fsPath: packageJsonPath }] : [],
+        );
         readFileAsyncStub = sandbox.stub(fsAsync, 'readFileAsync');
         iconsDisabledStub = sandbox.stub(ManifestReader, 'iconsDisabled');
       });
@@ -155,6 +157,39 @@ describe('ProjectAutoDetectionManager: NestJS project tests', function () {
 
           expect(readFileAsyncStub.calledWithExactly(packageJsonPath, 'utf8'))
             .to.be.true;
+          expect(res).to.be.an('array');
+          expect(firstResult).to.be.an('object');
+          expect(Reflect.ownKeys(firstResult)).to.have.lengthOf(5);
+          expect(firstResult).to.have.all.keys(
+            'apply',
+            'project',
+            'conflictingProjects',
+            'langResourceKey',
+            'value',
+          );
+          expect(firstResult).ownProperty('apply').to.be.true;
+          expect(firstResult).ownProperty('project').to.equal(Projects.nestjs);
+          expect(firstResult).ownProperty('conflictingProjects').to.be.empty;
+          expect(firstResult)
+            .ownProperty('langResourceKey')
+            .to.equal(LangResourceKeys.nestDetected);
+          expect(firstResult).ownProperty('value').to.be.true;
+        });
+      });
+
+      context(`detects a NestJS project from config files`, function () {
+        it('nest-cli.json', async function () {
+          const nestConfigPath = 'apps/api/nest-cli.json';
+          findFilesStub.callsFake((pattern: string) =>
+            pattern.includes('nest-cli.json') ? [{ fsPath: nestConfigPath }] : [],
+          );
+          getPresetStub.returns({ workspaceValue: undefined });
+          iconsDisabledStub.resolves(true);
+
+          const res = await padManager.detectProjects([Projects.nestjs]);
+          const firstResult = res[0];
+
+          expect(readFileAsyncStub.called).to.be.false;
           expect(res).to.be.an('array');
           expect(firstResult).to.be.an('object');
           expect(Reflect.ownKeys(firstResult)).to.have.lengthOf(5);


### PR DESCRIPTION
Auto-detect NestJS projects from nest-cli.json/.nest-cli.json/nestconfig.json/.nestconfig.json so Nest preset turns on without requiring @nestjs/core in package.json. Adds test coverage.