### PR TITLE
fix(icon): add .cts and .mts support to jest config

### DIFF
--- a/src/iconsManifest/supportedExtensions.ts
+++ b/src/iconsManifest/supportedExtensions.ts
@@ -2921,7 +2921,7 @@ export const extensions: IFileCollection = {
         'jest.config.integration',
         'jest.config.unit',
       ],
-      extensionsGlob: ['js', 'cjs', 'mjs', 'json', 'ts'],
+      extensionsGlob: ['js', 'cjs', 'mjs', 'json', 'ts', 'cts', 'mts'],
       filename: true,
       format: FileFormat.svg,
     },


### PR DESCRIPTION
_**Fixes part of #3991**_

**Changes proposed:**

- [x] Fix

Add support for `.cts` and `.mts` to [Jest](https://jestjs.io/). [Here](https://jestjs.io/docs/configuration) are the docs that reference the config file.
