### PR TITLE
feat(icon): add meson options to meson

### DIFF
--- a/src/iconsManifest/supportedExtensions.ts
+++ b/src/iconsManifest/supportedExtensions.ts
@@ -3599,6 +3599,12 @@ export const extensions: IFileCollection = {
       format: FileFormat.svg,
     },
     {
+      icon: 'meson',
+      extensions: ['meson.options', 'meson_options.txt'],
+      filename: true,
+      format: FileFormat.svg,
+    },
+    {
       icon: 'metal',
       extensions: [],
       languages: [languages.metal],


### PR DESCRIPTION
_**Fixes #N/A**_

**Changes proposed:**

- [x] Add

Add support for `meson.options` and `meson_options.txt`, a build options file for [Meson](https://mesonbuild.com/). Here is the filename reference: https://mesonbuild.com/Build-options.html

I also wanted to add the `.wrap` file extension related to #2180, and I found the [reference](https://mesonbuild.com/Wrap-dependency-system-manual.html) in the Meson Wrap dependency documentation. However, after reading the discussion there, I feel that I shouldn't.