### PR TITLE
refactor(icon): move liquid to use language ID

### DIFF
--- a/src/iconsManifest/languages.ts
+++ b/src/iconsManifest/languages.ts
@@ -328,6 +328,7 @@ export const languages = {
   lilypond: { ids: 'lilypond', knownExtensions: ['ly'] },
   lisp: { ids: ['lisp', 'autolisp', 'autolispdcl'], knownExtensions: ['lisp'] },
   literatehaskell: { ids: ['literate haskell'], knownExtensions: ['lhs'] },
+  liquid: { ids: ['liquid'], knownExtensions: ['liquid'] },
   log: { ids: 'log', knownExtensions: ['log'] },
   lolcode: { ids: 'lolcode', knownExtensions: ['lol'] },
   lsl: { ids: 'lsl', knownExtensions: ['lsl'] },

--- a/src/iconsManifest/supportedExtensions.ts
+++ b/src/iconsManifest/supportedExtensions.ts
@@ -3398,7 +3398,12 @@ export const extensions: IFileCollection = {
       filename: true,
       format: FileFormat.svg,
     },
-    { icon: 'liquid', extensions: ['liquid'], format: FileFormat.svg },
+    {
+      icon: 'liquid',
+      extensions: [],
+      languages: [languages.liquid],
+      format: FileFormat.svg,
+    },
     { icon: 'livescript', extensions: ['ls'], format: FileFormat.svg },
     { icon: 'lnk', extensions: ['lnk'], format: FileFormat.svg },
     { icon: 'locale', extensions: [], format: FileFormat.svg },


### PR DESCRIPTION
_**Fixes #N/A**_

**Changes proposed:**

- [x] Fix

Move `liquid` to use language ID provided by this VS Code extension: https://marketplace.visualstudio.com/items?itemName=Shopify.theme-check-vscode