### PR TITLE
chore(npm): disallow lifecycle scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -119,6 +119,11 @@
     "reflect-metadata": "^0.2.2",
     "semver": "^7.5.4"
   },
+  "allowScripts": {
+    "@playwright/browser-chromium": false,
+    "fsevents": false,
+    "unrs-resolver": false
+  },
   "preview": false,
   "capabilities": {
     "virtualWorkspaces": true,


### PR DESCRIPTION
Starting with npm 11, you can disallow dependencies from running lifecycle scripts. As of npm 12, the default behaviour is to fail installation if a script wasn’t configured explicitly.

This change disables all lifecycle scripts, but tells npm it’s ok to continue installation.