### PR TITLE
feat(icon): add support for Apple strings files

### DIFF
--- a/src/iconsManifest/languages.ts
+++ b/src/iconsManifest/languages.ts
@@ -619,6 +619,7 @@ export const languages = {
   stata: { ids: 'stata', knownExtensions: ['do'] },
   stencil: { ids: 'stencil', knownExtensions: ['stencil'] },
   stencilhtml: { ids: 'stencil-html', knownExtensions: ['html.stencil'] },
+  strings: { ids: 'strings', knownExtensions: ['strings'] },
   stylable: { ids: 'stylable', knownExtensions: ['st.css'] },
   styled: { ids: 'source.css.styled', knownExtensions: ['styled'] },
   stylus: { ids: 'stylus', knownExtensions: ['styl'] },

--- a/src/iconsManifest/supportedExtensions.ts
+++ b/src/iconsManifest/supportedExtensions.ts
@@ -3419,7 +3419,12 @@ export const extensions: IFileCollection = {
     },
     { icon: 'livescript', extensions: ['ls'], format: FileFormat.svg },
     { icon: 'lnk', extensions: ['lnk'], format: FileFormat.svg },
-    { icon: 'locale', extensions: [], format: FileFormat.svg },
+    {
+      icon: 'locale',
+      extensions: [],
+      languages: [languages.strings],
+      format: FileFormat.svg,
+    },
     { icon: 'log', extensions: ['log', 'tlg'], format: FileFormat.svg },
     {
       icon: 'log',


### PR DESCRIPTION
This change applies the locale icon to strings files. These are translation files for Xcode projects. The language ID is registered by https://marketplace.visualstudio.com/items?itemName=mhcpnl.xcodestrings

**Changes proposed:**

- [x] Add
