### PR TITLE
feat(icon): add devenv.lock filename support

### DIFF
--- a/src/iconsManifest/supportedExtensions.ts
+++ b/src/iconsManifest/supportedExtensions.ts
@@ -4031,6 +4031,12 @@ export const extensions: IFileCollection = {
       languages: [languages.nix],
       format: FileFormat.svg,
     },
+    {
+      icon: 'nix',
+      extensions: ['devenv.lock'],
+      filename: true,
+      format: FileFormat.svg,
+    },
     { icon: 'njsproj', extensions: ['njsproj'], format: FileFormat.svg },
     {
       icon: 'node',


### PR DESCRIPTION
_**Fixes #4112**_

**Changes proposed:**

- [x] Add
- [ ] Delete
- [ ] Fix
- [ ] Prepare

## Summary

Associate the existing `nix` icon with the `devenv.lock` filename generated by [devenv](https://devenv.sh/), a Nix-based developer environment tool.

Reuses the existing `icons/file_type_nix.svg` (no new SVG).

## Why a separate entry

Added as a separate entry rather than merged into the existing `nix` extensions entry (which maps `flake.lock`), mirroring the `.opentofu-version` / `opentofu` precedent (#4031). This:

1. Keeps the Nix Flakes lockfile (`flake.lock`) — which is owned by the Nix project — distinct from `devenv.lock`, which is a devenv-specific convention.
2. Allows a future migration to a dedicated devenv-specific icon by changing only the `icon` field of the new entry, leaving the existing Nix mapping untouched.

## Verification

- `npm run lint` ✅
- `npm test` ✅
- `npm run build:dev` ✅
- Generated `vsicons-icon-theme.json` contains `"devenv.lock": "_f_nix"` in `fileNames` (and same for `vsicons-icon-theme-zed.json`).