### PR TITLE
feat(folder): add storage to db folder mapping

### DIFF
--- a/src/iconsManifest/supportedFolders.ts
+++ b/src/iconsManifest/supportedFolders.ts
@@ -234,6 +234,8 @@ export const extensions: IFolderCollection = {
         'repositories',
         'store',
         'stores',
+        'storage',
+        'storages',
       ],
       format: FileFormat.svg,
     },


### PR DESCRIPTION
_**Fixes #3597**_

**Changes proposed:**

- [x] Add

Add `storage` and `storages` to `db` folder icon mapping.