### PR TITLE
feat(icon): add livekit icon

### DIFF
--- a/icons/file_type_light_livekit.svg
+++ b/icons/file_type_light_livekit.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 32 32"><path fill="#002cf2" d="M18.8 13.2h-5.6v5.6h5.6zM24.4 7.6h-5.6v5.6h5.6zM24.4 18.8h-5.6v5.6h5.6zM30 2h-5.6v5.6H30ZM30 24.4h-5.6V30H30Z"/><path fill="#000" d="M7.6 24.4V2H2v28h16.8v-5.6h-5.6Z"/></svg>

--- a/icons/file_type_livekit.svg
+++ b/icons/file_type_livekit.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 32 32"><path fill="#1fd5f9" d="M18.8 13.2h-5.6v5.6h5.6zM24.4 7.6h-5.6v5.6h5.6zM24.4 18.8h-5.6v5.6h5.6zM30 2h-5.6v5.6H30zM30 24.4h-5.6V30H30z"/><path fill="#d2d2d2" d="M7.6 24.4V2H2v28h16.8v-5.6h-5.6Z"/></svg>

--- a/src/iconsManifest/supportedExtensions.ts
+++ b/src/iconsManifest/supportedExtensions.ts
@@ -3467,6 +3467,13 @@ export const extensions: IFileCollection = {
       languages: [languages.liquid],
       format: FileFormat.svg,
     },
+    {
+      icon: 'livekit',
+      extensions: ['livekit.yaml', 'livekit.toml'],
+      filename: true,
+      light: true,
+      format: FileFormat.svg,
+    },
     { icon: 'livescript', extensions: ['ls'], format: FileFormat.svg },
     { icon: 'lnk', extensions: ['lnk'], format: FileFormat.svg },
     {


### PR DESCRIPTION
_**Fixes #N/A**_

**Changes proposed:**

- [x] Add

Add support for [LiveKit](https://livekit.com/).
- [`livekit.yaml`](https://docs.livekit.io/transport/self-hosting/vm/#generate-configuration) - LiveKit server configuration file.
- [`livekit.toml`](https://docs.livekit.io/deploy/agents/managing-deployments/#toml) - Agent deployment configuration file.

The icon was taken from [here](https://livekit.com/brand).