### PR TITLE
FIX : add missing extensions icon for mxml

### DIFF
--- a/icons/file_type_mxml.svg
+++ b/icons/file_type_mxml.svg
@@ -1,0 +1,33 @@
+<svg xmlns="http://www.w3.org/2000/svg"
+     viewBox="0 0 85 85">
+
+    <defs>
+        <style>
+            .accent {
+                fill: #C41718;
+                font-family: Arial, Helvetica, sans-serif;
+                font-weight: 700;
+                font-size: 38px;
+            }
+
+            .stroke {
+                fill: none;
+                stroke: #C41718;
+                stroke-width: 6;
+                stroke-linecap: round;
+                stroke-linejoin: round;
+            }
+        </style>
+    </defs>
+
+    <polyline class="stroke"
+        points="18,21 4,41 18,61"/>
+
+    <polyline class="stroke"
+        points="67,21 81,41 67,61"/>
+
+    <text class="accent"
+          x="18"
+          y="51">Mx</text>
+
+</svg>

--- a/src/iconsManifest/languages.ts
+++ b/src/iconsManifest/languages.ts
@@ -404,6 +404,7 @@ export const languages = {
   mvt: { ids: 'mvt', knownExtensions: ['mvt'] },
   mvtcss: { ids: 'mvtcss', knownExtensions: ['mvt'] },
   mvtjs: { ids: 'mvtjs', knownExtensions: ['mvt'] },
+  mxml: { ids: 'mxml', knownExtensions: ['mxml'] },
   nearley: { ids: 'nearley', knownExtensions: ['ne'] },
   nextflow: { ids: 'nextflow', knownExtensions: ['nf'] },
   nginx: { ids: ['nginx'], knownExtensions: ['nginx'] },

--- a/src/iconsManifest/supportedExtensions.ts
+++ b/src/iconsManifest/supportedExtensions.ts
@@ -3845,6 +3845,12 @@ export const extensions: IFileCollection = {
       format: FileFormat.svg,
     },
     {
+      icon: 'mxml',
+      extensions: [],
+      languages: [languages.mxml],
+      format: FileFormat.svg,
+    },
+    {
       icon: 'mypy',
       extensions: ['mypy.ini', '.mypy.ini'],
       filename: true,

--- a/src/iconsManifest/supportedExtensions.ts
+++ b/src/iconsManifest/supportedExtensions.ts
@@ -53,7 +53,7 @@ export const extensions: IFileCollection = {
     },
     {
       icon: 'actionscript',
-      extensions: [],
+      extensions: ['.part'],
       languages: [languages.actionscript],
       format: FileFormat.svg,
     },

--- a/src/iconsManifest/supportedExtensions.ts
+++ b/src/iconsManifest/supportedExtensions.ts
@@ -6801,7 +6801,12 @@ export const extensions: IFileCollection = {
     },
     {
       icon: 'xml',
-      extensions: ['pex', 'tmlanguage'],
+      extensions: ['pex',
+        'tmlanguage',
+        '.actionScriptProperties',
+        '.flexLibProperties',
+        '.project',
+        '.flexProperties'],
       languages: [languages.xml],
       format: FileFormat.svg,
     },

--- a/src/iconsManifest/supportedExtensions.ts
+++ b/src/iconsManifest/supportedExtensions.ts
@@ -2230,7 +2230,7 @@ export const extensions: IFileCollection = {
       filename: true,
       format: FileFormat.svg,
     },
-    { icon: 'flash', extensions: ['swf', 'swc'], format: FileFormat.svg },
+    { icon: 'flash', extensions: ['swf', 'swc', 'swf.cache', 'swc.cache'], format: FileFormat.svg },
     {
       icon: 'flatbuffers',
       extensions: [],


### PR DESCRIPTION
Add mxml logo for as3 & mxml language
<img width="150" height="150" alt="file_type_mxml" src="https://github.com/user-attachments/assets/83ff9561-8ff8-439b-a8aa-8fd48bee0a5f" />

