### PR TITLE
feat(icon): add WGSL language ID to wgsl

### DIFF
--- a/src/iconsManifest/languages.ts
+++ b/src/iconsManifest/languages.ts
@@ -701,7 +701,7 @@ export const languages = {
   wasp: { ids: 'wasp', knownExtensions: ['wasp'] },
   wenyan: { ids: 'wenyan', knownExtensions: ['wy'] },
   wesl: { ids: 'wesl', knownExtensions: ['wesl'] },
-  wgsl: { ids: 'wgsl', knownExtensions: ['wgsl'] },
+  wgsl: { ids: ['wgsl', 'WGSL'], knownExtensions: ['wgsl'] },
   wikitext: { ids: 'wikitext', knownExtensions: ['wt'] },
   wolfram: { ids: 'wolfram', knownExtensions: ['wl'] },
   wurst: { ids: ['wurstlang', 'wurst'], knownExtensions: ['wurst'] },


### PR DESCRIPTION
_**Fixes #3322**_

**Changes proposed:**

- [x] Add

Add support for the WGSL language ID provided by the VS Code extension: https://marketplace.visualstudio.com/items?itemName=ybwork.ybwork-wgsl.

I checked all WGSL language support extensions available on the VS Code Marketplace and found that `WGSL` (uppercase) is the only language ID currently missing. I believe this may also be related to #3322.

The only other related language ID I found is `wgsl_template`, provided by https://marketplace.visualstudio.com/items?itemName=fs-eire.wgsl-template. Since it is specifically used for `.wgsl.template` files rather than `.wgsl` files, I don't think it should be included here.