### PR TITLE
feat(icon): add GLua language ID to Lua

### DIFF
--- a/src/iconsManifest/languages.ts
+++ b/src/iconsManifest/languages.ts
@@ -334,7 +334,7 @@ export const languages = {
   log: { ids: 'log', knownExtensions: ['log'] },
   lolcode: { ids: 'lolcode', knownExtensions: ['lol'] },
   lsl: { ids: 'lsl', knownExtensions: ['lsl'] },
-  lua: { ids: 'lua', knownExtensions: ['lua'] },
+  lua: { ids: ['lua', 'glua'], knownExtensions: ['lua'] },
   m4: { ids: 'm4', knownExtensions: ['m4'] },
   makefile: { ids: ['makefile', 'makefile2'], knownExtensions: ['mk'] },
   markdown: {


### PR DESCRIPTION
<!-- markdownlint-disable MD041-->

_**Fixes #N/A**_

**Changes proposed:**

- [x] Add

Add support for `GLua` language ID to support VS Code extensions that add it, such as: [GLua Enhanced](https://marketplace.visualstudio.com/items?itemName=venner.vscode-glua-enhanced), [glua (aSP)](https://marketplace.visualstudio.com/items?itemName=aStonedPenguin.glua), [glua (yobson)](https://marketplace.visualstudio.com/items?itemName=yobson.glua). Main Glua documentation: [GMod Wiki](https://wiki.facepunch.com/gmod/). I have tested this locally and the Lua icon is now appearing for `.lua` files when GLua language is selected from any of the extensions.

Before:
<img width="175" height="309" alt="image" src="https://github.com/user-attachments/assets/9c1fda9f-6593-4436-a446-f32c2892320c" />

After:
<img width="175" height="315" alt="image" src="https://github.com/user-attachments/assets/e2eecb44-ed47-48b2-b756-9120a9df3e24" />