### PR TITLE
fix(icon): add missing .js, .mjs, and .mts support for alchemy

### DIFF
--- a/src/iconsManifest/supportedExtensions.ts
+++ b/src/iconsManifest/supportedExtensions.ts
@@ -488,7 +488,9 @@ export const extensions: IFileCollection = {
     },
     {
       icon: 'alchemy',
-      extensions: ['alchemy.run.ts'],
+      extensions: [],
+      filenamesGlob: ['alchemy.run'],
+      extensionsGlob: ['js', 'mjs', 'ts', 'mts'],
       filename: true,
       format: FileFormat.svg,
     },


### PR DESCRIPTION
_**Fixes #N/A**_

**Changes proposed:**

- [x] Fix

Add missing .js, .mjs, and .mts support for [Alchemy](https://alchemy.run/). 
See: https://github.com/alchemy-run/alchemy/blob/main/alchemy/bin/services/execute-alchemy.ts#L209-L214 for filename reference.
