### PR TITLE
fix(icon): add missing prisma.* and js/ts variation for prisma

### DIFF
--- a/src/iconsManifest/supportedExtensions.ts
+++ b/src/iconsManifest/supportedExtensions.ts
@@ -4851,8 +4851,8 @@ export const extensions: IFileCollection = {
     {
       icon: 'prismaconfig',
       extensions: [],
-      filenamesGlob: ['prisma.config'],
-      extensionsGlob: ['js', 'ts'],
+      filenamesGlob: ['prisma', 'prisma.config'],
+      extensionsGlob: ['js', 'cjs', 'mjs', 'ts', 'cts', 'mts'],
       filename: true,
       format: FileFormat.svg,
     },


### PR DESCRIPTION
_**Fixes part of #3991**_

**Changes proposed:**

- [x] Fix

Add support for `prisma.*` and missing extension such as `.cjs`, `.mjs`, `.cts`, and `.mts`. See https://www.prisma.io/docs/orm/reference/prisma-config-reference#supported-file-extensions for more details.