### PR TITLE
fix(icon): Fix the extensions for the Wasp folder icon

### DIFF
--- a/src/iconsManifest/supportedFolders.ts
+++ b/src/iconsManifest/supportedFolders.ts
@@ -922,7 +922,7 @@ export const extensions: IFolderCollection = {
     },
     {
       icon: 'wasp',
-      extensions: ['wasp'],
+      extensions: ['.wasp'],
       format: FileFormat.svg,
     },
     {


### PR DESCRIPTION
Refs #4095<!-- markdownlint-disable MD041-->

Fixes the implementation from https://github.com/vscode-icons/vscode-icons/pull/4123
That PR accidentally added `wasp` as the Wasp framework output dir, instead of `.wasp`.

<!-- Please first read how to submit a pull request, if you haven't already done so.
https://github.com/vscode-icons/vscode-icons/wiki/PullRequest -->

**Changes proposed:**

- [ ] Add
- [ ] Delete
- [ ] Fix
- [ ] Prepare
