### PR TITLE
feat(icon): add ejs language ID

### DIFF
--- a/src/iconsManifest/languages.ts
+++ b/src/iconsManifest/languages.ts
@@ -179,6 +179,7 @@ export const languages = {
   edge: { ids: 'edge', knownExtensions: ['edge'] },
   editorconfig: { ids: 'editorconfig', knownFilenames: ['.editorconfig'] },
   eex: { ids: ['eex', 'html-eex'], knownExtensions: ['eex'] },
+  ejs: { ids: 'ejs', knownExtensions: ['ejs'] },
   elastic: { ids: 'es', knownExtensions: ['es'] },
   elixir: { ids: 'elixir', knownExtensions: ['ex'] },
   elm: { ids: 'elm', knownExtensions: ['elm'] },

--- a/src/iconsManifest/supportedExtensions.ts
+++ b/src/iconsManifest/supportedExtensions.ts
@@ -1960,7 +1960,12 @@ export const extensions: IFileCollection = {
       languages: [languages.eex],
       format: FileFormat.svg,
     },
-    { icon: 'ejs', extensions: ['ejs'], format: FileFormat.svg },
+    {
+      icon: 'ejs',
+      extensions: ['ejs'],
+      languages: [languages.ejs],
+      format: FileFormat.svg,
+    },
     {
       icon: 'elastic',
       extensions: [],


### PR DESCRIPTION
_**Fixes #N/A**_

**Changes proposed:**

- [x] Add

Add `ejs` language ID provided by https://marketplace.visualstudio.com/items?itemName=DigitalBrainstem.javascript-ejs-support.

The purpose of this addition is not to display an icon in the file tree, but to show the appropriate icon in the Language Mode picker.

| Before | After |
|--------|-------|
| <img width="145" height="97" alt="image" src="https://github.com/user-attachments/assets/ce1370be-4256-45d4-97f5-0d62d538ac6b" /> |  <img width="156" height="100" alt="image" src="https://github.com/user-attachments/assets/357fdbb0-4540-40b8-be53-01b9977c3d7b" /> |

I also noticed that VS Code natively recognizes `.ejs` files as `html`, as shown here: https://github.com/microsoft/vscode/blob/main/extensions/html/package.json#L31. Therefore, I didn't remove the `extension` from `supportedExtension.ts`, since it is still recognized and handled as `html` by default.

