### PR TITLE
feat(icon): support translation and translations

### DIFF
--- a/src/iconsManifest/supportedFolders.ts
+++ b/src/iconsManifest/supportedFolders.ts
@@ -503,6 +503,8 @@ export const extensions: IFolderCollection = {
         'i18n',
         'g11n',
         'l10n',
+        'translation',
+        'translations'
       ],
       format: FileFormat.svg,
     },

--- a/src/iconsManifest/supportedFolders.ts
+++ b/src/iconsManifest/supportedFolders.ts
@@ -504,7 +504,7 @@ export const extensions: IFolderCollection = {
         'g11n',
         'l10n',
         'translation',
-        'translations'
+        'translations',
       ],
       format: FileFormat.svg,
     },


### PR DESCRIPTION
_**Fixes #N/A**_

**Changes proposed:**
- [x] Add

- Add `translation` and `translations` to the existing `locale` folder icons mapping.