### PR TITLE
fix(icon): support mts to next config

### DIFF
--- a/src/iconsManifest/supportedExtensions.ts
+++ b/src/iconsManifest/supportedExtensions.ts
@@ -4064,12 +4064,8 @@ export const extensions: IFileCollection = {
     },
     {
       icon: 'next',
-      extensions: [
-        'next.config.js',
-        'next.config.cjs',
-        'next.config.mjs',
-        'next.config.ts',
-      ],
+      filenamesGlob: ['next.config'],
+      extensionsGlob: ['js', 'cjs', 'mjs', 'ts', 'mts'],
       filename: true,
       light: true,
       format: FileFormat.svg,

--- a/src/iconsManifest/supportedExtensions.ts
+++ b/src/iconsManifest/supportedExtensions.ts
@@ -4064,6 +4064,7 @@ export const extensions: IFileCollection = {
     },
     {
       icon: 'next',
+      extensions: [],
       filenamesGlob: ['next.config'],
       extensionsGlob: ['js', 'cjs', 'mjs', 'ts', 'mts'],
       filename: true,


### PR DESCRIPTION
_**Fixes part of #3991**_

**Changes proposed:**

- [x] Fix

Add `mts` support to [Next](https://nextjs.org/) config. Here are the reference: https://github.com/vercel/next.js/blob/canary/packages/next/src/shared/lib/constants.ts#L109-L116.

I couldn't find the reference for `cts`, and in the reference I gave, `cjs` is not available either. Should I remove it?
