### PR TITLE
refactor(icon): move mustache to use language ID

### DIFF
--- a/src/iconsManifest/languages.ts
+++ b/src/iconsManifest/languages.ts
@@ -402,6 +402,10 @@ export const languages = {
   mojolicious: { ids: 'mojolicious', knownExtensions: ['ep'] },
   mongo: { ids: 'mongo', knownExtensions: ['mongo'] },
   mson: { ids: 'mson', knownExtensions: ['mson'] },
+  mustache: {
+    ids: 'mustache',
+    knownExtensions: ['mustche', 'mst', 'mu', 'stache'],
+  },
   mv: { ids: 'mv', knownExtensions: ['mv'] },
   mvt: { ids: 'mvt', knownExtensions: ['mvt'] },
   mvtcss: { ids: 'mvtcss', knownExtensions: ['mvt'] },

--- a/src/iconsManifest/languages.ts
+++ b/src/iconsManifest/languages.ts
@@ -404,7 +404,7 @@ export const languages = {
   mson: { ids: 'mson', knownExtensions: ['mson'] },
   mustache: {
     ids: 'mustache',
-    knownExtensions: ['mustche', 'mst', 'mu', 'stache'],
+    knownExtensions: ['mustache', 'mst', 'mu', 'stache'],
   },
   mv: { ids: 'mv', knownExtensions: ['mv'] },
   mvt: { ids: 'mvt', knownExtensions: ['mvt'] },

--- a/src/iconsManifest/supportedExtensions.ts
+++ b/src/iconsManifest/supportedExtensions.ts
@@ -3865,7 +3865,8 @@ export const extensions: IFileCollection = {
     },
     {
       icon: 'mustache',
-      extensions: ['mustache', 'mst'],
+      extensions: [],
+      languages: [languages.mustache],
       light: true,
       format: FileFormat.svg,
     },


### PR DESCRIPTION
_**Fixes #N/A**_

**Changes proposed:**

- [x] Fix

Move `mustache` to use language ID provided by [Mustache](https://marketplace.visualstudio.com/items?itemName=dawhite.mustache), [Mustache Syntax](https://marketplace.visualstudio.com/items?itemName=attilabuti.mustache-syntax-vscode), and [Mustache Templates - Syntax Highlighting, Snippets & Autocomplete](https://marketplace.visualstudio.com/items?itemName=imgildev.vscode-mustache-snippets).