### PR TITLE
feat(icon): use dist icon for output folder

### DIFF
--- a/src/iconsManifest/supportedFolders.ts
+++ b/src/iconsManifest/supportedFolders.ts
@@ -268,6 +268,8 @@ export const extensions: IFolderCollection = {
         'dists',
         'out',
         'outs',
+        'output',
+        'outputs',
         'export',
         'exports',
         'build',


### PR DESCRIPTION
The `dist` folder icon is already used for the `out` and `outs` directories. These are really just short for `output` and `outputs`. I recently encountered a project that used the `output` directory, so I figured it makes sense to apply the icon.

**Changes proposed:**

- [x] Add