### PR TITLE
feat(icon): extend buckbuild filename entry

### DIFF
--- a/src/iconsManifest/supportedExtensions.ts
+++ b/src/iconsManifest/supportedExtensions.ts
@@ -928,7 +928,7 @@ export const extensions: IFileCollection = {
     },
     {
       icon: 'buckbuild',
-      extensions: ['.buckconfig'],
+      extensions: ['.buckconfig', '.buckconfig.local', '.buckjavaargs', 'BUCK'],
       filename: true,
       format: FileFormat.svg,
     },


### PR DESCRIPTION
_**Fixes #N/A**_

**Changes proposed:**

- [x] Add

Add support for more `buck.build` filenames.

- [`.buckconfig.local`](https://buck.build/files-and-dirs/buckconfig.html) — local version of `.buckconfig` file ([Buck2 reference](https://buck2.build/docs/concepts/buckconfig/#buckconfiglocal))
- [`.buckjavaargs`](https://buck.build/files-and-dirs/buckjavaargs.html) — config file to read JVM flags (only exists in Buck1)
- [`BUCK`](https://buck.build/concept/build_file.html) — default build file ([Buck2 reference](https://buck2.build/docs/concepts/build_file/))

[Buck1](https://buck.build/) and [Buck2](https://buck2.build/) have different logos — I think this should be updated, but I'm not sure myself.

<img width="150" height="150" alt="file_type_buckbuild2" src="https://github.com/user-attachments/assets/ee0829d6-534c-4296-b374-5184a95465b0" />

