### PR TITLE
feat(icon): use tsconfig icon for tsfmt.json

### DIFF
--- a/src/iconsManifest/supportedExtensions.ts
+++ b/src/iconsManifest/supportedExtensions.ts
@@ -6274,6 +6274,7 @@ export const extensions: IFileCollection = {
         'tsconfig.types',
         'tsconfig.lib',
         'tsconfig.lib.prod',
+        'tsfmt',
       ],
       extensionsGlob: ['json'],
       filename: true,


### PR DESCRIPTION
`tsfmt` is a formatter that uses TypeScript’s builtin formatting capabilities. Its default configuration file is `tsfmt.json`. It doesn’t have its own file icon, but using `tsconfig` seems appropriate.

**Changes proposed:**

- [x] Add
