### PR TITLE
fix(buf): add missing `filename` property

### DIFF
--- a/src/iconsManifest/supportedExtensions.ts
+++ b/src/iconsManifest/supportedExtensions.ts
@@ -951,6 +951,7 @@ export const extensions: IFileCollection = {
         'buf.work.yml',
       ],
       languages: [languages.buf],
+      filename: true,
       format: FileFormat.svg,
     },
     {


### PR DESCRIPTION
<!-- markdownlint-disable MD041-->
**Changes proposed:**

- [x] Fix

The extensions for Buf config files represent whole filenames so a `filename: true` property is required but was missing