### PR TITLE
fix(bruno): add missing extension

### DIFF
--- a/src/iconsManifest/languages.ts
+++ b/src/iconsManifest/languages.ts
@@ -61,7 +61,7 @@ export const languages = {
     ids: 'browserslist',
     knownFilenames: ['browserslist', '.browserslistrc'],
   },
-  bruno: { ids: 'bruno', knownExtensions: ['bru'] },
+  bruno: { ids: 'bru', knownExtensions: ['bru'] },
   buf: { ids: ['buf', 'buf-gen'], knownExtensions: ['buf.yaml'] },
   bunlockb: { ids: 'bun.lockb', knownExtensions: ['lockb'] },
   c: { ids: 'c', knownExtensions: ['c'] },

--- a/src/iconsManifest/supportedExtensions.ts
+++ b/src/iconsManifest/supportedExtensions.ts
@@ -930,8 +930,9 @@ export const extensions: IFileCollection = {
     },
     {
       icon: 'bruno',
-      extensions: [],
+      extensions: ['.bru'],
       languages: [languages.bruno],
+      filename: false,
       format: FileFormat.svg,
     },
     {

--- a/src/iconsManifest/supportedExtensions.ts
+++ b/src/iconsManifest/supportedExtensions.ts
@@ -930,7 +930,7 @@ export const extensions: IFileCollection = {
     },
     {
       icon: 'bruno',
-      extensions: ['.bru'],
+      extensions: ['bru'],
       languages: [languages.bruno],
       filename: false,
       format: FileFormat.svg,


### PR DESCRIPTION
<!-- markdownlint-disable MD041-->
**Changes proposed:**

- [x] Fix

Add missing extension for Bruno files and `filename: false` property