### PR TITLE
feat(icon): add zsh icon

### DIFF
--- a/icons/file_type_zsh.svg
+++ b/icons/file_type_zsh.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" fill="none" stroke="#f15a24" stroke-linecap="round" stroke-width="2.11" viewBox="0 0 32 32"><circle cx="5.85" cy="11.9" r="2.6"/><circle cx="12" cy="20.1" r="2.6"/><path stroke-width="1.35" d="M15.2 8.54 2.68 23.46m26.65-.37h-8.95"/></svg>

--- a/src/iconsManifest/supportedExtensions.ts
+++ b/src/iconsManifest/supportedExtensions.ts
@@ -7154,5 +7154,18 @@ export const extensions: IFileCollection = {
       filename: true,
       format: FileFormat.svg,
     },
+    {
+      icon: 'zsh',
+      extensions: [
+        '.zlogin',
+        '.zprofile',
+        '.zshrc',
+        'zlogin',
+        'zprofile',
+        'zshrc',
+      ],
+      filename: true,
+      format: FileFormat.svg,
+    },
   ],
 };


### PR DESCRIPTION
The file names are taken from https://zsh.sourceforge.io/Guide/zshguide02.html. The icon used is the favicon of https://www.zsh.org.

**Changes proposed:**

- [x] Add
