### PR TITLE
Add .swift-version and .xcode-version file associations

### DIFF
--- a/src/iconsManifest/supportedExtensions.ts
+++ b/src/iconsManifest/supportedExtensions.ts
@@ -5987,7 +5987,7 @@ export const extensions: IFileCollection = {
     },
     {
       icon: 'swift',
-      extensions: ['package.pins'],
+      extensions: ['package.pins', '.swift-version'],
       filename: true,
       languages: [languages.swift],
       format: FileFormat.svg,
@@ -6931,6 +6931,12 @@ export const extensions: IFileCollection = {
       format: FileFormat.svg,
     },
     { icon: 'xcode', extensions: ['xcodeproj'], format: FileFormat.svg },
+    {
+      icon: 'xcode',
+      extensions: ['.xcode-version'],
+      filename: true,
+      format: FileFormat.svg,
+    },
     {
       icon: 'xfl',
       extensions: ['xfl'],


### PR DESCRIPTION
<!-- markdownlint-disable MD041-->

<!-- Please first read how to submit a pull request, if you haven't already done so.
https://github.com/vscode-icons/vscode-icons/wiki/PullRequest -->

**Changes proposed:**

- [x] Add

Adds file-name associations for two Xcode/Swift toolchain version-pin dotfiles that currently fall back to the generic file icon:

- `.swift-version` -> existing `swift` icon (same icon already used for `package.pins`)
- `.xcode-version` -> existing `xcode` icon (same icon already used for `.xcodeproj`)

`.xcode-version` is a convention proposed and documented in [XcodesOrg/xcodes](https://github.com/XcodesOrg/xcodes/blob/main/XCODE_VERSION.md) (supported by fastlane, xcode-install, and various CI setups) that lets tooling automatically install/switch to the Xcode version a project needs, analogous to `.node-version`/`.ruby-version`/`.python-version`, which are already supported here.

No new SVGs needed - both changes reuse existing icons via `filename: true` entries in `src/iconsManifest/supportedExtensions.ts`, following the pattern documented in the [Fine tuning wiki page](https://github.com/vscode-icons/vscode-icons/wiki/FineTuning).

`npm run lint`, `npm run compile:dev`, and `npm test` (707 passing) all pass locally.
