### PR TITLE
feat(icon): support Unity IL2CPP metadata files

### DIFF
--- a/src/iconsManifest/supportedExtensions.ts
+++ b/src/iconsManifest/supportedExtensions.ts
@@ -5682,6 +5682,12 @@ export const extensions: IFileCollection = {
       format: FileFormat.svg,
     },
     {
+      icon: 'shaderlab',
+      extensions: ['global-metadata.dat'],
+      filename: true,
+      format: FileFormat.svg,
+    },
+    {
       icon: 'shadcn',
       extensions: ['components.json'],
       filename: true,


### PR DESCRIPTION
## Summary

- Associate Unity IL2CPP's `global-metadata.dat` with the existing ShaderLab icon.
- Match the complete filename so unrelated `.dat` files retain their current associations.

## Verification

- `npm test` — 707 passing
- `npm run lint` — passed
